### PR TITLE
refactor: unify Model methods to pointer receiver

### DIFF
--- a/internal/tui/highlight.go
+++ b/internal/tui/highlight.go
@@ -197,7 +197,7 @@ func writeStyledText(sb *strings.Builder, ansi, text string) {
 	}
 }
 
-func (m Model) getHighlightedLine(lineIdx int) *highlightedLine {
+func (m *Model) getHighlightedLine(lineIdx int) *highlightedLine {
 	if m.highlightedLines != nil && lineIdx >= 0 && lineIdx < len(m.highlightedLines) {
 		return &m.highlightedLines[lineIdx]
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -97,7 +97,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 
 // contextKeyMap returns a help.KeyMap with bindings enabled/disabled
 // based on the current TUI state.
-func (m Model) contextKeyMap() help.KeyMap {
+func (m *Model) contextKeyMap() help.KeyMap {
 	km := m.keys
 	km.Comment.SetEnabled(m.focusPane == 1)
 	km.ClearAll.SetEnabled(m.focusPane == 1)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -78,10 +78,10 @@ type Model struct {
 }
 
 // NewModel creates a new TUI Model.
-func NewModel(srv MCPServer, ctx context.Context, rootDir string, watcher *fsnotify.Watcher, dirWatcher *fsnotify.Watcher) Model {
+func NewModel(srv MCPServer, ctx context.Context, rootDir string, watcher *fsnotify.Watcher, dirWatcher *fsnotify.Watcher) *Model {
 	absRootDir, err := filepath.Abs(rootDir)
 	if err != nil {
-		return Model{server: srv, ctx: ctx, err: err}
+		return &Model{server: srv, ctx: ctx, err: err}
 	}
 
 	ft := buildFileTree(absRootDir)
@@ -90,7 +90,7 @@ func NewModel(srv MCPServer, ctx context.Context, rootDir string, watcher *fsnot
 	ti.Placeholder = "Enter comment..."
 	ti.CharLimit = 500
 
-	return Model{
+	return &Model{
 		server:       srv,
 		ctx:          ctx,
 		rootDir:      absRootDir,

--- a/internal/tui/notify.go
+++ b/internal/tui/notify.go
@@ -6,7 +6,7 @@ import (
 )
 
 // notifySelectionChanged sends the current selection to the MCP server.
-func (m Model) notifySelectionChanged() {
+func (m *Model) notifySelectionChanged() {
 	startLine, startChar := m.anchorLine, m.anchorChar
 	endLine, endChar := m.cursorLine, m.cursorChar
 
@@ -56,7 +56,7 @@ func (m Model) notifySelectionChanged() {
 }
 
 // notifyClearSelection sends a clear-selection notification.
-func (m Model) notifyClearSelection() {
+func (m *Model) notifyClearSelection() {
 	m.server.NotifySelectionChanged(
 		m.filePath,
 		"",
@@ -68,7 +68,7 @@ func (m Model) notifyClearSelection() {
 }
 
 // notifyComment sends a comment as a selection_changed notification.
-func (m Model) notifyComment(line int, comment string) {
+func (m *Model) notifyComment(line int, comment string) {
 	text := fmt.Sprintf("[Comment] %s:%d\n%s", m.filePath, line+1, comment)
 
 	m.server.NotifySelectionChanged(

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -9,12 +9,12 @@ import (
 )
 
 // Init implements tea.Model.
-func (m Model) Init() tea.Cmd {
+func (m *Model) Init() tea.Cmd {
 	return tea.Batch(m.watchFile(), m.watchDir())
 }
 
 // lineLen returns the rune-length of the given line.
-func (m Model) lineLen(line int) int {
+func (m *Model) lineLen(line int) int {
 	if line < 0 || line >= len(m.lines) {
 		return 0
 	}
@@ -22,7 +22,7 @@ func (m Model) lineLen(line int) int {
 }
 
 // getTreeWidth returns the tree pane width.
-func (m Model) getTreeWidth() int {
+func (m *Model) getTreeWidth() int {
 	if m.treeWidth > 0 {
 		tw := m.treeWidth
 		if tw < 15 {
@@ -38,7 +38,7 @@ func (m Model) getTreeWidth() int {
 }
 
 // getContentHeight returns the content area height.
-func (m Model) getContentHeight() int {
+func (m *Model) getContentHeight() int {
 	contentHeight := m.height - 5
 	if contentHeight < 5 {
 		contentHeight = 5
@@ -47,7 +47,7 @@ func (m Model) getContentHeight() int {
 }
 
 // getScrollOffset returns the current scroll offset.
-func (m Model) getScrollOffset() int {
+func (m *Model) getScrollOffset() int {
 	return m.scrollOffset
 }
 
@@ -96,7 +96,7 @@ func (m *Model) adjustScrollForCursor() {
 }
 
 // Update implements tea.Model.
-func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case fileChangedMsg:
 		m.lines = msg.lines

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -21,7 +21,7 @@ var (
 )
 
 // View implements tea.Model.
-func (m Model) View() string {
+func (m *Model) View() string {
 	if m.err != nil {
 		return fmt.Sprintf("Error: %v\n\nPress Esc to quit.", m.err)
 	}
@@ -72,7 +72,7 @@ func (m Model) View() string {
 }
 
 // renderFooter generates the footer area (help hints + status).
-func (m Model) renderFooter() string {
+func (m *Model) renderFooter() string {
 	var sb strings.Builder
 
 	if m.inputMode {
@@ -112,7 +112,7 @@ func (m Model) renderFooter() string {
 }
 
 // renderTree generates the tree pane lines.
-func (m Model) renderTree(width, height int) []string {
+func (m *Model) renderTree(width, height int) []string {
 	lines := make([]string, 0, height)
 
 	for i := m.treeScrollOffset; i < len(m.fileTree) && len(lines) < height; i++ {
@@ -148,7 +148,7 @@ func (m Model) renderTree(width, height int) []string {
 }
 
 // renderEditor generates the editor pane lines.
-func (m Model) renderEditor(width, height int) []string {
+func (m *Model) renderEditor(width, height int) []string {
 	lines := make([]string, 0, height)
 
 	if len(m.lines) == 0 {
@@ -234,7 +234,7 @@ func selRange(line, startLine, endLine, startChar, endChar int, content string) 
 }
 
 // renderLineWithCursor renders a line with an inverted cursor.
-func (m Model) renderLineWithCursor(sb *strings.Builder, line string) {
+func (m *Model) renderLineWithCursor(sb *strings.Builder, line string) {
 	runes := []rune(line)
 	if m.cursorChar >= len(runes) {
 		sb.WriteString(expandTabs(line))
@@ -254,7 +254,7 @@ func (m Model) renderLineWithCursor(sb *strings.Builder, line string) {
 }
 
 // renderLineWithCursorAndSelection renders a line with selection highlight.
-func (m Model) renderLineWithCursorAndSelection(sb *strings.Builder, line string, selStart, selEnd int) {
+func (m *Model) renderLineWithCursorAndSelection(sb *strings.Builder, line string, selStart, selEnd int) {
 	runes := []rune(line)
 	if selStart > len(runes) {
 		selStart = len(runes)

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // watchFile returns a tea.Cmd that watches the current file for changes.
-func (m Model) watchFile() tea.Cmd {
+func (m *Model) watchFile() tea.Cmd {
 	return func() tea.Msg {
 		if m.watcher == nil {
 			return nil
@@ -41,7 +41,7 @@ func (m Model) watchFile() tea.Cmd {
 }
 
 // watchDir returns a tea.Cmd that watches directories for changes.
-func (m Model) watchDir() tea.Cmd {
+func (m *Model) watchDir() tea.Cmd {
 	return func() tea.Msg {
 		if m.dirWatcher == nil {
 			return nil


### PR DESCRIPTION
## Overview

Model の全メソッドを pointer receiver に統一するリファクタリング。

変更前は 22 メソッド中 19 が value receiver、3 つだけ pointer receiver という不一致があった。
Update サイクルごとに Model 全体がコピーされる非効率も解消される。

## Changes

- `NewModel` の戻り値を `Model` から `*Model` に変更
- value receiver だった 19 メソッドを全て pointer receiver に変更
  - `update.go`: `Init`, `Update`, `lineLen`, `getTreeWidth`, `getContentHeight`, `getScrollOffset`
  - `view.go`: `View`, `renderFooter`, `renderTree`, `renderEditor`, `renderLineWithCursor`, `renderLineWithCursorAndSelection`
  - `keys.go`: `contextKeyMap`
  - `notify.go`: `notifySelectionChanged`, `notifyClearSelection`, `notifyComment`
  - `watch.go`: `watchFile`, `watchDir`
  - `highlight.go`: `getHighlightedLine`
- 既に pointer receiver だったメソッド (`loadFile`, `adjustTreeScroll`, `adjustScrollForCursor`) は変更なし
- `cmd/gra/main.go` は `*Model` が `tea.Model` を満たすため変更不要

## Test

```bash
go build ./...  # OK
go test ./...   # OK
```
