### PR TITLE
feat: add v/V key for Vim-style visual selection

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -6,20 +6,17 @@ import (
 )
 
 type keyMap struct {
-	Quit         key.Binding
-	SwitchPane   key.Binding
-	Enter        key.Binding
-	Up           key.Binding
-	Down         key.Binding
-	Left         key.Binding
-	Right        key.Binding
-	ShiftUp      key.Binding
-	ShiftDown    key.Binding
-	ShiftLeft    key.Binding
-	ShiftRight   key.Binding
-	ToggleSelect key.Binding
-	Comment      key.Binding
-	ClearAll     key.Binding
+	Quit       key.Binding
+	SwitchPane key.Binding
+	Enter      key.Binding
+	Up         key.Binding
+	Down       key.Binding
+	Left       key.Binding
+	Right      key.Binding
+	CharSelect key.Binding
+	LineSelect key.Binding
+	Comment    key.Binding
+	ClearAll   key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -52,25 +49,13 @@ func newKeyMap() keyMap {
 			key.WithKeys("right"),
 			key.WithHelp("→", "right"),
 		),
-		ShiftUp: key.NewBinding(
-			key.WithKeys("shift+up"),
-			key.WithHelp("Shift+↑", "select up"),
-		),
-		ShiftDown: key.NewBinding(
-			key.WithKeys("shift+down"),
-			key.WithHelp("Shift+↓", "select down"),
-		),
-		ShiftLeft: key.NewBinding(
-			key.WithKeys("shift+left"),
-			key.WithHelp("Shift+←", "select left"),
-		),
-		ShiftRight: key.NewBinding(
-			key.WithKeys("shift+right"),
-			key.WithHelp("Shift+→", "select right"),
-		),
-		ToggleSelect: key.NewBinding(
+		CharSelect: key.NewBinding(
 			key.WithKeys("v"),
 			key.WithHelp("v", "select"),
+		),
+		LineSelect: key.NewBinding(
+			key.WithKeys("V"),
+			key.WithHelp("V", "select line"),
 		),
 		Comment: key.NewBinding(
 			key.WithKeys("i"),
@@ -87,7 +72,7 @@ func newKeyMap() keyMap {
 func (k keyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.SwitchPane, k.Up, k.Down,
-		k.ToggleSelect, k.Comment, k.ClearAll, k.Quit,
+		k.CharSelect, k.LineSelect, k.Comment, k.ClearAll, k.Quit,
 	}
 }
 
@@ -95,8 +80,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right},
-		{k.ShiftUp, k.ShiftDown, k.ShiftLeft, k.ShiftRight},
-		{k.Enter, k.SwitchPane, k.ToggleSelect, k.Comment, k.ClearAll, k.Quit},
+		{k.Enter, k.SwitchPane, k.CharSelect, k.LineSelect, k.Comment, k.ClearAll, k.Quit},
 	}
 }
 
@@ -104,7 +88,8 @@ func (k keyMap) FullHelp() [][]key.Binding {
 // based on the current TUI state.
 func (m *Model) contextKeyMap() help.KeyMap {
 	km := m.keys
-	km.ToggleSelect.SetEnabled(m.focusPane == paneEditor)
+	km.CharSelect.SetEnabled(m.focusPane == paneEditor)
+	km.LineSelect.SetEnabled(m.focusPane == paneEditor)
 	km.Comment.SetEnabled(m.focusPane == paneEditor)
 	km.ClearAll.SetEnabled(m.focusPane == paneEditor)
 	return km

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -22,6 +22,7 @@ type tab struct {
 	anchorLine       int
 	anchorChar       int
 	selecting        bool
+	lineSelect       bool
 	scrollOffset     int
 
 	comments     map[int]string
@@ -50,6 +51,10 @@ func (t *tab) normalizedSelection() (startLine, startChar, endLine, endChar int)
 	if startLine > endLine || (startLine == endLine && startChar > endChar) {
 		startLine, endLine = endLine, startLine
 		startChar, endChar = endChar, startChar
+	}
+	if t.lineSelect {
+		startChar = 0
+		endChar = t.lineLen(endLine)
 	}
 	return
 }
@@ -96,6 +101,7 @@ func (t *tab) resetEditorState() {
 	t.anchorChar = 0
 	t.scrollOffset = 0
 	t.selecting = false
+	t.lineSelect = false
 	t.comments = make(map[int]string)
 	t.inputMode = false
 	t.commentInput.Reset()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -222,6 +222,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Quit):
 			if t.selecting {
 				t.selecting = false
+				t.lineSelect = false
 				m.notifyClearSelection()
 				return m, nil
 			}
@@ -250,7 +251,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			} else {
-				t.selecting = false
 				if t.cursorChar > 0 {
 					t.cursorChar--
 				} else if t.cursorLine > 0 {
@@ -269,7 +269,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			} else {
-				t.selecting = false
 				if t.cursorChar < t.lineLen(t.cursorLine) {
 					t.cursorChar++
 				} else if t.cursorLine < len(t.lines)-1 {
@@ -285,7 +284,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.treeCursor--
 				}
 			} else {
-				t.selecting = false
 				if t.cursorLine > 0 {
 					t.cursorLine--
 					t.cursorChar = min(t.cursorChar, t.lineLen(t.cursorLine))
@@ -299,7 +297,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.treeCursor++
 				}
 			} else {
-				t.selecting = false
 				if t.cursorLine < len(t.lines)-1 {
 					t.cursorLine++
 					t.cursorChar = min(t.cursorChar, t.lineLen(t.cursorLine))
@@ -307,45 +304,31 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.notifySelectionChanged()
 				}
 			}
-		case key.Matches(msg, m.keys.ShiftUp):
-			if t.cursorLine > 0 {
-				t.startSelecting()
-				t.cursorLine--
-				t.cursorChar = min(t.cursorChar, t.lineLen(t.cursorLine))
-				m.notifySelectionChanged()
-			}
-		case key.Matches(msg, m.keys.ShiftDown):
-			if t.cursorLine < len(t.lines)-1 {
-				t.startSelecting()
-				t.cursorLine++
-				t.cursorChar = min(t.cursorChar, t.lineLen(t.cursorLine))
-				m.notifySelectionChanged()
-			}
-		case key.Matches(msg, m.keys.ShiftLeft):
-			t.startSelecting()
-			if t.cursorChar > 0 {
-				t.cursorChar--
-			} else if t.cursorLine > 0 {
-				t.cursorLine--
-				t.cursorChar = t.lineLen(t.cursorLine)
-			}
-			m.notifySelectionChanged()
-		case key.Matches(msg, m.keys.ShiftRight):
-			t.startSelecting()
-			if t.cursorChar < t.lineLen(t.cursorLine) {
-				t.cursorChar++
-			} else if t.cursorLine < len(t.lines)-1 {
-				t.cursorLine++
-				t.cursorChar = 0
-			}
-			m.notifySelectionChanged()
-		case key.Matches(msg, m.keys.ToggleSelect):
+		case key.Matches(msg, m.keys.CharSelect):
 			if m.focusPane == paneEditor && len(t.lines) > 0 {
-				if t.selecting {
+				if t.selecting && !t.lineSelect {
 					t.selecting = false
 					m.notifyClearSelection()
+				} else if t.selecting && t.lineSelect {
+					t.lineSelect = false
+					m.notifySelectionChanged()
 				} else {
 					t.startSelecting()
+				}
+			}
+		case key.Matches(msg, m.keys.LineSelect):
+			if m.focusPane == paneEditor && len(t.lines) > 0 {
+				if t.selecting && t.lineSelect {
+					t.selecting = false
+					t.lineSelect = false
+					m.notifyClearSelection()
+				} else if t.selecting && !t.lineSelect {
+					t.lineSelect = true
+					m.notifySelectionChanged()
+				} else {
+					t.startSelecting()
+					t.lineSelect = true
+					m.notifySelectionChanged()
 				}
 			}
 		case key.Matches(msg, m.keys.Comment):

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -175,7 +175,13 @@ func (m *Model) renderEditor(width, height int) []string {
 
 		if isCursorLine && isSelected {
 			sc, ec := selRange(i, startLine, endLine, startChar, endChar, lineContent)
-			if hl := t.getHighlightedLine(i); hl != nil {
+			if sc == ec {
+				if hl := t.getHighlightedLine(i); hl != nil {
+					renderStyledLineWithCursor(&sb, hl.runs, t.cursorChar)
+				} else {
+					renderLineWithCursor(&sb, lineContent, t.cursorChar)
+				}
+			} else if hl := t.getHighlightedLine(i); hl != nil {
 				renderStyledLineWithSelection(&sb, hl.runs, sc, ec)
 			} else {
 				renderLineWithCursorAndSelection(&sb, lineContent, sc, ec)


### PR DESCRIPTION
## Overview

Add Vim-style visual selection with `v` (character-wise) and
`V` (line-wise) keys. Remove Shift+arrow selection in favor of
the new selection modes.

## Changes

### Selection modes

- `v`: toggle character-wise selection
- `V`: toggle line-wise selection
- Arrow keys extend selection while in either mode
- `v` / `V` again or Escape to cancel selection
- Switch between modes: `v` <-> `V` (matches Vim behavior)

### Files changed

- `keys.go`: add `CharSelect` (`v`) / `LineSelect` (`V`) bindings,
  remove Shift+arrow bindings
- `tab.go`: add `lineSelect` flag, `normalizedSelection` forces
  `startChar=0` / `endChar=EOL` in line-wise mode
- `update.go`: add `CharSelect` / `LineSelect` handlers with
  mode switching, remove Shift+arrow handlers,
  Escape clears selection before quitting
- `view.go`: fix cursor disappearing when selection range is
  zero-width (immediately after pressing `v`)

## Related

Built on top of the tab struct refactoring from #5 .

## Test plan

- [ ] `go build` success
- [ ] `v` starts/cancels character-wise selection
- [ ] `V` starts/cancels line-wise selection
- [ ] `v` -> `V` switches to line-wise
- [ ] `V` -> `v` switches to character-wise
- [ ] Escape cancels selection without quitting
- [ ] Escape quits when not selecting