### PR TITLE
feat: use themed background color for selection highlight

### DIFF
--- a/internal/tui/highlight.go
+++ b/internal/tui/highlight.go
@@ -7,10 +7,34 @@ import (
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 )
 
-const defaultThemeName = "github-dark"
+type themeConfig struct {
+	name        string // Chroma style name
+	selectionBg string // ANSI SGR sequence for selection background
+}
+
+var (
+	darkTheme = themeConfig{
+		name:        "github-dark",
+		selectionBg: termenv.CSI + termenv.RGBColor("#264F78").Sequence(true) + "m",
+	}
+	lightTheme = themeConfig{
+		name:        "github",
+		selectionBg: termenv.CSI + termenv.RGBColor("#ADD6FF").Sequence(true) + "m",
+	}
+	activeTheme = darkTheme // default fallback
+)
+
+func init() {
+	if lipgloss.HasDarkBackground() {
+		activeTheme = darkTheme
+	} else {
+		activeTheme = lightTheme
+	}
+}
 
 var (
 	ansiInverse = termenv.CSI + termenv.ReverseSeq + "m"
@@ -34,7 +58,7 @@ func highlightFile(filePath, source string) []highlightedLine {
 	}
 	lexer = chroma.Coalesce(lexer)
 
-	style := styles.Get(defaultThemeName)
+	style := styles.Get(activeTheme.name)
 
 	iterator, err := lexer.Tokenise(nil, source)
 	if err != nil {
@@ -174,7 +198,10 @@ func renderStyledLineWithSelection(sb *strings.Builder, runs []styledRun, selSta
 			// Within selection
 			selLocalStart := overlapStart - runStart
 			selLocalEnd := overlapEnd - runStart
-			sb.WriteString(ansiInverse)
+			if run.ANSI != "" {
+				sb.WriteString(run.ANSI)
+			}
+			sb.WriteString(activeTheme.selectionBg)
 			sb.WriteString(expandTabs(string(runes[selLocalStart:selLocalEnd])))
 			sb.WriteString(ansiReset)
 

--- a/internal/tui/highlight_test.go
+++ b/internal/tui/highlight_test.go
@@ -119,14 +119,24 @@ func TestRenderStyledLineWithSelection(t *testing.T) {
 	renderStyledLineWithSelection(&sb, runs, 2, 7) // select "llo w"
 	output := sb.String()
 
-	if !strings.Contains(output, "\033[7m") {
-		t.Error("expected inverse video for selection")
+	// Selection should use the active theme's selectionBg, not inverse video
+	if !strings.Contains(output, activeTheme.selectionBg) {
+		t.Error("expected selection background color in output")
+	}
+
+	// The run's foreground ANSI should be preserved within the selection
+	if !strings.Contains(output, "\033[38;5;148m") {
+		t.Error("expected foreground ANSI to be preserved in selection")
 	}
 
 	// Check that selection contains the right text
-	invIdx := strings.Index(output, "\033[7m")
-	resetIdx := strings.Index(output[invIdx:], "\033[0m")
-	selected := output[invIdx+len("\033[7m") : invIdx+resetIdx]
+	selBgIdx := strings.Index(output, activeTheme.selectionBg)
+	afterSelBg := output[selBgIdx+len(activeTheme.selectionBg):]
+	resetIdx := strings.Index(afterSelBg, "\033[0m")
+	if resetIdx < 0 {
+		t.Fatal("expected reset after selection background")
+	}
+	selected := afterSelBg[:resetIdx]
 	if selected != "llo w" {
 		t.Errorf("expected selected text 'llo w', got %q", selected)
 	}


### PR DESCRIPTION
## Overview

選択ハイライトの見た目を ANSI inverse video から VS Code 風のテーマカラーに変更する。

## Changes

- `themeConfig` 構造体を追加し、Chroma スタイル名と選択背景色をペアで管理
- `lipgloss.HasDarkBackground()` でターミナル背景を検出し、dark (#264F78) / light (#ADD6FF) を自動切替
- `renderStyledLineWithSelection` で前景色 (シンタックスハイライト) を維持しつつ背景色のみ変更
- カーソル描画 (`renderStyledLineWithCursor`) は従来どおり inverse video を使用

## Test plan

- [x] `go test ./...` パス
- [x] `go build -o gra ./cmd/gra/` 成功
- [ ] v / V キーで選択し、背景が青色になることを目視確認
- [ ] シンタックスハイライトが選択中も維持されることを目視確認