### PR TITLE
chore: update twig symlinks pattern for user_instructions

### DIFF
--- a/.twig/settings.toml
+++ b/.twig/settings.toml
@@ -6,7 +6,7 @@ default_source = "main"
 
 # Symlink patterns to create in new worktrees
 # Recommend: [".twig/settings.local.toml"] to share local settings across worktrees
-symlinks = [".twig/settings.local.toml", ".claude/settings.local.json", ".claude/user_instructions"]
+symlinks = [".twig/settings.local.toml", ".claude/settings.local.json", ".claude/user_instructions/*.md"]
 
 # Worktree destination base directory (default: ../<repo-name>-worktree)
 # worktree_destination_base_dir = "../my-worktrees"


### PR DESCRIPTION
## Summary

- Update twig symlinks setting from `.claude/user_instructions` (directory) to `.claude/user_instructions/*.md` (glob pattern)

## Test plan

- [ ] Verify `.claude/user_instructions/*.md` files are correctly symlinked when creating a new worktree