### PR TITLE
feat: add hjkl vim-style navigation keybindings

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -43,20 +43,20 @@ func newKeyMap() keyMap {
 			key.WithHelp("Enter", "open/toggle"),
 		),
 		Up: key.NewBinding(
-			key.WithKeys("up"),
-			key.WithHelp("↑", "up"),
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "up"),
 		),
 		Down: key.NewBinding(
-			key.WithKeys("down"),
-			key.WithHelp("↓", "down"),
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "down"),
 		),
 		Left: key.NewBinding(
-			key.WithKeys("left"),
-			key.WithHelp("←", "left"),
+			key.WithKeys("left", "h"),
+			key.WithHelp("←/h", "left"),
 		),
 		Right: key.NewBinding(
-			key.WithKeys("right"),
-			key.WithHelp("→", "right"),
+			key.WithKeys("right", "l"),
+			key.WithHelp("→/l", "right"),
 		),
 		CharSelect: key.NewBinding(
 			key.WithKeys("v"),


### PR DESCRIPTION
## Overview

Add vim-style hjkl navigation keybindings.

## Why

Currently cursor movement only supports arrow keys,
requiring users to move their hands away from the home row.
Adding hjkl navigation allows keyboard-centric operation.

## What

- Add k/j/h/l as alternative keys for Up/Down/Left/Right
  bindings in `internal/tui/keys.go`
- Update help text (e.g. `↑` → `↑/k`)
- Only `internal/tui/keys.go` is changed

## Type of Change

- [x] Feature

## How to Test

1. Build with `go build -o gra ./cmd/gra/`
2. Verify j/k moves cursor up/down in file tree pane
3. Verify h/l collapses/expands directories in file tree pane
4. Verify hjkl moves cursor in editor pane
5. Verify hjkl types text in comment input mode
6. Verify H/L tab switching still works

## Checklist

- [x] Self-reviewed