### PR TITLE
feat: highlight active tab file in file tree

### DIFF
--- a/internal/tui/highlight.go
+++ b/internal/tui/highlight.go
@@ -15,6 +15,7 @@ type themeConfig struct {
 	name            string // Chroma style name
 	selectionBg     string // Editor selection background hex color
 	listSelectionBg string // List/tree active selection hex color
+	activeFileBg    string // File tree active-tab file background hex color
 	tabActiveFg     string // Active tab foreground hex color
 	tabActiveBorder string // Active tab underline hex color
 	tabInactiveFg   string // Inactive tab foreground hex color
@@ -29,6 +30,7 @@ var (
 		name:            "github-dark",
 		selectionBg:     "#264F78",
 		listSelectionBg: "#37373D",
+		activeFileBg:    "#2A2D2E",
 		tabActiveFg:     "#FFFFFF",
 		tabActiveBorder: "#E8AB53",
 		tabInactiveFg:   "#969696",
@@ -37,6 +39,7 @@ var (
 		name:            "github",
 		selectionBg:     "#ADD6FF",
 		listSelectionBg: "#B8D8F8",
+		activeFileBg:    "#E4E6F1",
 		tabActiveFg:     "#333333",
 		tabActiveBorder: "#005FB8",
 		tabInactiveFg:   "#6E6E6E",

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -200,12 +200,12 @@ func (m *Model) renderTree(width, height int) []string {
 		displayLine = padRight(displayLine, width)
 
 		switch {
-		case isCursor && isActiveFile:
-			displayLine = styleTreeCursor().Bold(true).Render(displayLine)
 		case isCursor:
 			displayLine = styleTreeCursor().Render(displayLine)
 		case isActiveFile:
-			displayLine = lipgloss.NewStyle().Bold(true).Render(displayLine)
+			displayLine = lipgloss.NewStyle().
+				Background(lipgloss.Color(activeTheme.activeFileBg)).
+				Render(displayLine)
 		}
 
 		displayLine = icon.colorize(displayLine)


### PR DESCRIPTION
## Overview

Highlight the active tab file in the file tree pane with a background color.

## Why

There was no visual indication in the file tree of which file is currently
open in the editor pane. Similar to VS Code's Explorer, highlighting the
active tab file makes it easy to identify the currently edited file.

## What

- Compare each entry's `path` with the active tab's `filePath` in `renderTree`
- Add `activeFileBg` to `themeConfig` (dark: `#2A2D2E`, light: `#E4E6F1`)
- Cursor position: `listSelectionBg` (`#37373D`) with a stronger background
- Active tab file: `activeFileBg` (`#2A2D2E`) with a subtler background
- Visually distinguish cursor from active tab by background color intensity

## Type of Change

- [x] Feature

## How to Test

1. Build with `go build -o gra ./cmd/gra/`
2. Select a file in the file tree to open it in the editor
3. Verify the file has a subtle background color in the tree
4. Verify the cursor background takes priority when on the active file
5. Verify the highlight moves when opening a different file
6. Verify the highlight works for diff tab files as well

## Checklist

- [x] Self-reviewed