### PR TITLE
fix: unify empty-state message and use ASCII in quit help label

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -33,7 +33,7 @@ func newKeyMap() keyMap {
 	return keyMap{
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c"),
-			key.WithHelp("Ctrl+C×2", "quit"),
+			key.WithHelp("Ctrl+C (2x)", "quit"),
 		),
 		Cancel: key.NewBinding(
 			key.WithKeys("esc"),

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -13,6 +13,8 @@ var separatorBorder = lipgloss.Border{
 	Top: "\u2500",
 }
 
+const emptyStateMsg = "Select a file to view"
+
 var (
 	styleComment = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	styleFooter  = lipgloss.NewStyle().
@@ -180,7 +182,7 @@ func (m *Model) renderFooter() string {
 				fmt.Fprintf(&sb, "Cursor: %d:%d",
 					t.cursorLine+1, t.cursorChar+1)
 			default:
-				sb.WriteString("Select a file to view")
+				sb.WriteString(emptyStateMsg)
 			}
 		case m.treeCursor < len(m.fileTree):
 			entry := m.fileTree[m.treeCursor]
@@ -252,7 +254,7 @@ func (m *Model) renderEditor(width, height int) []string {
 	lines := make([]string, 0, height)
 
 	if !hasTab || len(t.lines) == 0 {
-		emptyMsg := "No file selected"
+		emptyMsg := emptyStateMsg
 		lines = append(lines, padRight(emptyMsg, width))
 		for len(lines) < height {
 			lines = append(lines, padRight("", width))


### PR DESCRIPTION
## Summary

- Extract duplicated empty-state string `"Select a file to view"` into a shared `emptyStateMsg` constant in `view.go`
- Replace the multiplication sign (`×`) in the quit help label with ASCII `(2x)` for consistent rendering across terminals

## Changes

### `internal/tui/view.go`
- Add `emptyStateMsg` constant to deduplicate the empty-state message used in both `renderFooter` and `renderEditor`

### `internal/tui/keys.go`
- Change quit key help label from `Ctrl+C×2` to `Ctrl+C (2x)` to avoid non-ASCII character rendering issues

## Test plan

- [x] `go test ./...` passes
- [ ] Verify the quit help label renders correctly in the footer
- [ ] Verify the empty-state message displays consistently when no file is selected