### PR TITLE
feat: add Option+Left/Right word movement in editor pane

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -14,6 +14,8 @@ type keyMap struct {
 	Down          key.Binding
 	Left          key.Binding
 	Right         key.Binding
+	WordLeft      key.Binding
+	WordRight     key.Binding
 	CharSelect    key.Binding
 	LineSelect    key.Binding
 	Copy          key.Binding
@@ -63,6 +65,14 @@ func newKeyMap() keyMap {
 		Right: key.NewBinding(
 			key.WithKeys("right", "l"),
 			key.WithHelp("→/l", "right"),
+		),
+		WordLeft: key.NewBinding(
+			key.WithKeys("alt+left", "alt+h"),
+			key.WithHelp("Alt+←/h", "word left"),
+		),
+		WordRight: key.NewBinding(
+			key.WithKeys("alt+right", "alt+l"),
+			key.WithHelp("Alt+→/l", "word right"),
 		),
 		CharSelect: key.NewBinding(
 			key.WithKeys("v"),
@@ -134,7 +144,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 // FullHelp returns key bindings for the full help view.
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Up, k.Down, k.Left, k.Right, k.GoTop, k.GoBottom, k.BlockUp, k.BlockDown},
+		{k.Up, k.Down, k.Left, k.Right, k.WordLeft, k.WordRight, k.GoTop, k.GoBottom, k.BlockUp, k.BlockDown},
 		{k.Enter, k.SwitchPane, k.PrevTab, k.NextTab, k.CloseTab},
 		{k.CharSelect, k.LineSelect, k.Copy, k.Comment, k.ClearAll, k.OpenFile, k.Cancel, k.Quit},
 	}
@@ -152,6 +162,8 @@ func (m *Model) contextKeyMap() help.KeyMap {
 	km.ClearAll.SetEnabled(hasTab && m.focusPane == paneEditor)
 	km.NextTab.SetEnabled(hasTab)
 	km.PrevTab.SetEnabled(hasTab)
+	km.WordLeft.SetEnabled(hasTab && m.focusPane == paneEditor)
+	km.WordRight.SetEnabled(hasTab && m.focusPane == paneEditor)
 	km.CloseTab.SetEnabled(hasTab)
 	km.SwitchPane.SetEnabled(hasTab)
 	return km

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -37,6 +37,125 @@ const (
 	dirDown direction = 1
 )
 
+// charClass categorizes runes for word movement (VS Code 3-class model).
+type charClass int
+
+const (
+	classSpace charClass = iota
+	classWord
+	classSep
+)
+
+// runeClass returns the character class of a rune.
+func runeClass(r rune) charClass {
+	switch {
+	case unicode.IsSpace(r):
+		return classSpace
+	case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_':
+		return classWord
+	default:
+		return classSep
+	}
+}
+
+// moveWordLeft moves the cursor one word to the left.
+func (m *Model) moveWordLeft() {
+	t, hasTab := m.activeTabState()
+	if !hasTab || m.focusPane != paneEditor || len(t.lines) == 0 {
+		return
+	}
+	runes := []rune(t.lines[t.cursorLine])
+	pos := t.cursorChar
+
+	// At line start, move to previous line end.
+	if pos == 0 {
+		if t.cursorLine > 0 {
+			t.cursorLine--
+			t.cursorChar = t.lineLen(t.cursorLine)
+			t.syncAnchorToCursor()
+			m.notifySelectionChanged()
+		}
+		return
+	}
+
+	pos--
+
+	// Skip whitespace backward.
+	for pos > 0 && runeClass(runes[pos]) == classSpace {
+		pos--
+	}
+	if runeClass(runes[pos]) == classSpace {
+		// Entire prefix was whitespace; move to previous line end.
+		if t.cursorLine > 0 {
+			t.cursorLine--
+			t.cursorChar = t.lineLen(t.cursorLine)
+		} else {
+			t.cursorChar = 0
+		}
+		t.syncAnchorToCursor()
+		m.notifySelectionChanged()
+		return
+	}
+
+	// Skip same-class characters backward.
+	cls := runeClass(runes[pos])
+	for pos > 0 && runeClass(runes[pos-1]) == cls {
+		pos--
+	}
+	t.cursorChar = pos
+	t.syncAnchorToCursor()
+	m.notifySelectionChanged()
+}
+
+// moveWordRight moves the cursor one word to the right.
+func (m *Model) moveWordRight() {
+	t, hasTab := m.activeTabState()
+	if !hasTab || m.focusPane != paneEditor || len(t.lines) == 0 {
+		return
+	}
+	runes := []rune(t.lines[t.cursorLine])
+	lineLen := len(runes)
+	pos := t.cursorChar
+
+	// At line end, move to next line start.
+	if pos >= lineLen {
+		if t.cursorLine < len(t.lines)-1 {
+			t.cursorLine++
+			t.cursorChar = 0
+			t.syncAnchorToCursor()
+			m.notifySelectionChanged()
+		}
+		return
+	}
+
+	// Skip current class forward.
+	cls := runeClass(runes[pos])
+	for pos < lineLen && runeClass(runes[pos]) == cls {
+		pos++
+	}
+
+	// Skip whitespace forward.
+	for pos < lineLen && runeClass(runes[pos]) == classSpace {
+		pos++
+	}
+	if pos >= lineLen {
+		// Reached line end; move to next line start.
+		if t.cursorLine < len(t.lines)-1 {
+			t.cursorLine++
+			t.cursorChar = 0
+		} else {
+			t.cursorChar = lineLen
+		}
+		t.syncAnchorToCursor()
+		m.notifySelectionChanged()
+		return
+	}
+
+	t.cursorChar = pos
+	t.syncAnchorToCursor()
+	m.notifySelectionChanged()
+}
+
 // isBlankLine returns true if the line contains only whitespace.
 func isBlankLine(s string) bool {
 	return !strings.ContainsFunc(s, func(r rune) bool {
@@ -392,6 +511,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focusPane == paneTree && len(m.fileTree) > 0 {
 				m.toggleTreeEntry(m.treeCursor)
 			}
+		case key.Matches(msg, m.keys.WordLeft):
+			m.moveWordLeft()
+		case key.Matches(msg, m.keys.WordRight):
+			m.moveWordRight()
 		case key.Matches(msg, m.keys.Left):
 			if m.focusPane == paneTree {
 				if len(m.fileTree) > 0 {

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1,0 +1,261 @@
+package tui
+
+import "testing"
+
+// mockServer implements MCPServer for testing.
+type mockServer struct{}
+
+func (mockServer) Port() int { return 0 }
+func (mockServer) NotifySelectionChanged(string, string, int, int, int, int) {
+}
+
+// helper to set up a minimal Model with lines and cursor position.
+func newTestModel(lines []string, cursorLine, cursorChar int) *Model {
+	t := &tab{
+		lines:      lines,
+		cursorLine: cursorLine,
+		cursorChar: cursorChar,
+	}
+	return &Model{
+		tabs:      []*tab{t},
+		activeTab: 0,
+		focusPane: paneEditor,
+		keys:      newKeyMap(),
+		server:    mockServer{},
+	}
+}
+
+func TestWordLeft(t *testing.T) {
+	tests := []struct {
+		name     string
+		lines    []string
+		line     int
+		char     int
+		wantLine int
+		wantChar int
+	}{
+		{
+			name:     "middle of word",
+			lines:    []string{"hello world"},
+			line:     0,
+			char:     8,
+			wantLine: 0,
+			wantChar: 6,
+		},
+		{
+			name:     "at word boundary",
+			lines:    []string{"hello world"},
+			line:     0,
+			char:     6,
+			wantLine: 0,
+			wantChar: 0,
+		},
+		{
+			name:     "separator boundary",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     4,
+			wantLine: 0,
+			wantChar: 3,
+		},
+		{
+			name:     "separator to word",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     3,
+			wantLine: 0,
+			wantChar: 0,
+		},
+		{
+			name:     "paren to word",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     12,
+			wantLine: 0,
+			wantChar: 11,
+		},
+		{
+			name:     "CJK treated as word",
+			lines:    []string{"hello世界test"},
+			line:     0,
+			char:     10,
+			wantLine: 0,
+			wantChar: 0,
+		},
+		{
+			name:     "line start wraps to previous line end",
+			lines:    []string{"hello", "world"},
+			line:     1,
+			char:     0,
+			wantLine: 0,
+			wantChar: 5,
+		},
+		{
+			name:     "file start stays at 0",
+			lines:    []string{"hello"},
+			line:     0,
+			char:     0,
+			wantLine: 0,
+			wantChar: 0,
+		},
+		{
+			name:     "skip whitespace then stop at word",
+			lines:    []string{"  hello"},
+			line:     0,
+			char:     7,
+			wantLine: 0,
+			wantChar: 2,
+		},
+		{
+			name:     "all whitespace wraps to previous line",
+			lines:    []string{"hello", "   "},
+			line:     1,
+			char:     3,
+			wantLine: 0,
+			wantChar: 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel(tc.lines, tc.line, tc.char)
+			m.moveWordLeft()
+			tab := m.tabs[0]
+			if tab.cursorLine != tc.wantLine || tab.cursorChar != tc.wantChar {
+				t.Errorf("got (%d, %d), want (%d, %d)",
+					tab.cursorLine, tab.cursorChar,
+					tc.wantLine, tc.wantChar)
+			}
+		})
+	}
+}
+
+func TestWordRight(t *testing.T) {
+	tests := []struct {
+		name     string
+		lines    []string
+		line     int
+		char     int
+		wantLine int
+		wantChar int
+	}{
+		{
+			name:     "move to next word",
+			lines:    []string{"hello world"},
+			line:     0,
+			char:     0,
+			wantLine: 0,
+			wantChar: 6,
+		},
+		{
+			name:     "from space to next word",
+			lines:    []string{"hello world"},
+			line:     0,
+			char:     5,
+			wantLine: 0,
+			wantChar: 6,
+		},
+		{
+			name:     "separator stops",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     0,
+			wantLine: 0,
+			wantChar: 3,
+		},
+		{
+			name:     "dot to next word",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     3,
+			wantLine: 0,
+			wantChar: 4,
+		},
+		{
+			name:     "paren to word",
+			lines:    []string{"foo.bar(baz)"},
+			line:     0,
+			char:     7,
+			wantLine: 0,
+			wantChar: 8,
+		},
+		{
+			name:     "CJK treated as word",
+			lines:    []string{"hello世界test"},
+			line:     0,
+			char:     0,
+			wantLine: 0,
+			wantChar: 11,
+		},
+		{
+			name:     "line end wraps to next line start",
+			lines:    []string{"hello", "world"},
+			line:     0,
+			char:     5,
+			wantLine: 1,
+			wantChar: 0,
+		},
+		{
+			name:     "file end stays",
+			lines:    []string{"hello"},
+			line:     0,
+			char:     5,
+			wantLine: 0,
+			wantChar: 5,
+		},
+		{
+			name:     "empty line wraps to next",
+			lines:    []string{"", "world"},
+			line:     0,
+			char:     0,
+			wantLine: 1,
+			wantChar: 0,
+		},
+		{
+			name:     "trailing space wraps to next line",
+			lines:    []string{"hello   ", "world"},
+			line:     0,
+			char:     5,
+			wantLine: 1,
+			wantChar: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel(tc.lines, tc.line, tc.char)
+			m.moveWordRight()
+			tab := m.tabs[0]
+			if tab.cursorLine != tc.wantLine || tab.cursorChar != tc.wantChar {
+				t.Errorf("got (%d, %d), want (%d, %d)",
+					tab.cursorLine, tab.cursorChar,
+					tc.wantLine, tc.wantChar)
+			}
+		})
+	}
+}
+
+func TestRuneClass(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want charClass
+	}{
+		{' ', classSpace},
+		{'\t', classSpace},
+		{'a', classWord},
+		{'Z', classWord},
+		{'0', classWord},
+		{'_', classWord},
+		{'世', classWord},
+		{'.', classSep},
+		{'(', classSep},
+		{'!', classSep},
+	}
+
+	for _, tc := range tests {
+		got := runeClass(tc.r)
+		if got != tc.want {
+			t.Errorf("runeClass(%q) = %d, want %d", tc.r, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

エディタペインに Alt+Left/Right (Alt+h/l) による単語区切りカーソル移動を追加する。

## Why

現在のエディタペインでは1文字単位の移動 (h/l, Left/Right) のみ対応しており、長い行での移動が非効率。VS Code と同様の単語単位移動を提供する。

## What

- VS Code 互換の3クラス文字分類モデルを実装 (word, separator, whitespace)
  - **Word**: 文字・数字・`_` (CJK文字含む)
  - **Separator**: 記号・句読点
  - **Whitespace**: 空白・タブ
- `moveWordLeft` / `moveWordRight` メソッドを追加
  - 行境界をまたぐ移動に対応
  - `moveToParagraphBoundary` と同じ自己完結パターン (syncAnchor + notify 内包)
- キーバインド: `Alt+Left` / `Alt+h` (左), `Alt+Right` / `Alt+l` (右)
- FullHelp のナビゲーション行に表示
- `contextKeyMap` で editor pane 時のみ有効化
- テストケース追加 (ASCII, 記号混在, CJK, 行境界, 空行, ファイル境界)

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test ./internal/tui/... -run TestWord
go build -o gra ./cmd/gra/ && ./gra
```

エディタペインで Alt+Left/Right または Alt+h/l を押して単語単位でカーソルが移動することを確認。

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed