### PR TITLE
feat: add word wrap for editor pane

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/mattn/go-runewidth v0.0.19
 	github.com/muesli/termenv v0.16.0
 	github.com/sahilm/fuzzy v0.1.1
 )
@@ -30,7 +31,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/tui/display.go
+++ b/internal/tui/display.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 // padRight pads a string with spaces to the given display width.
@@ -14,4 +15,65 @@ func padRight(s string, width int) string {
 // expandTabs replaces tabs with 4 spaces.
 func expandTabs(s string) string {
 	return strings.ReplaceAll(s, "\t", "    ")
+}
+
+// runeWidth returns the display width of a rune, treating tabs as 4 columns.
+func runeWidth(r rune) int {
+	if r == '\t' {
+		return 4
+	}
+	return runewidth.RuneWidth(r)
+}
+
+// wrapBreakpoints returns the rune indices at which line should be wrapped
+// to fit within textWidth display columns. Returns nil if the line fits
+// without wrapping or if textWidth <= 0.
+func wrapBreakpoints(line string, textWidth int) []int {
+	if textWidth <= 0 {
+		return nil
+	}
+	runes := []rune(line)
+	if len(runes) == 0 {
+		return nil
+	}
+
+	var breaks []int
+	col := 0
+	segStart := 0
+	for i, r := range runes {
+		w := runeWidth(r)
+		if col+w > textWidth && i > segStart {
+			breaks = append(breaks, i)
+			col = w
+			segStart = i
+		} else {
+			col += w
+		}
+	}
+	return breaks
+}
+
+// countWraps returns the number of visual rows a line occupies
+// when wrapped at textWidth. Returns 1 if no wrapping is needed.
+// Unlike wrapBreakpoints, this does not allocate a slice.
+func countWraps(line string, textWidth int) int {
+	if textWidth <= 0 {
+		return 1
+	}
+
+	count := 1
+	col := 0
+	charsInSeg := 0
+	for _, r := range line {
+		w := runeWidth(r)
+		if col+w > textWidth && charsInSeg > 0 {
+			count++
+			col = w
+			charsInSeg = 1
+		} else {
+			col += w
+			charsInSeg++
+		}
+	}
+	return count
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -45,6 +45,7 @@ type layout struct {
 	editorStartX  int // treeWidth + separatorWidth
 	editorWidth   int // total width - treeWidth - separatorWidth
 	lineNumWidth  int // line number gutter width (digits + 1 space)
+	textWidth     int // editorWidth - lineNumWidth
 }
 
 // getTreeWidth returns the tree pane width.
@@ -84,11 +85,13 @@ func (m *Model) computeLayout() layout {
 	if ok && len(t.lines) > 0 {
 		lnw = lineNumWidthFor(len(t.lines))
 	}
+	ew := m.width - tw - separatorWidth
 	return layout{
 		contentHeight: m.getContentHeight(),
 		treeWidth:     tw,
 		editorStartX:  tw + separatorWidth,
-		editorWidth:   m.width - tw - separatorWidth,
+		editorWidth:   ew,
 		lineNumWidth:  lnw,
+		textWidth:     ew - lnw,
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -115,6 +115,7 @@ const (
 type visualEntry struct {
 	logicalLine int
 	kind        lineKind
+	wrapOffset  int // rune offset in the logical line where this wrap segment starts
 }
 
 // activeTabState returns the active tab and whether it exists.

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -198,7 +198,7 @@ func (t *tab) resetEditorState() {
 }
 
 // adjustScrollForCursor adjusts the scroll so the cursor stays visible.
-func (t *tab) adjustScrollForCursor(contentHeight int) {
+func (t *tab) adjustScrollForCursor(contentHeight, textWidth int) {
 	margin := contentHeight / 5
 
 	// Cursor above visible area (logical check is sufficient)
@@ -207,11 +207,11 @@ func (t *tab) adjustScrollForCursor(contentHeight int) {
 	}
 
 	// Cursor below visible area (visual-row aware)
-	if t.visualRowsBetween(t.scrollOffset, t.cursorLine) > contentHeight-margin {
-		t.scrollOffset = t.scrollOffsetFor(t.cursorLine, contentHeight-margin)
+	if t.visualRowsBetween(t.scrollOffset, t.cursorLine, textWidth) > contentHeight-margin {
+		t.scrollOffset = t.scrollOffsetFor(t.cursorLine, contentHeight-margin, textWidth)
 	}
 
-	maxOffset := t.maxScrollOffset(contentHeight)
+	maxOffset := t.maxScrollOffset(contentHeight, textWidth)
 	if t.scrollOffset > maxOffset {
 		t.scrollOffset = maxOffset
 	}
@@ -221,9 +221,12 @@ func (t *tab) adjustScrollForCursor(contentHeight int) {
 }
 
 // lineVisualRows returns the number of visual rows a single line occupies,
-// including any comment block or active input attached to it.
-func (t *tab) lineVisualRows(line int) int {
+// including word-wrap rows and any comment block or active input attached to it.
+func (t *tab) lineVisualRows(line, textWidth int) int {
 	rows := 1
+	if textWidth > 0 && line >= 0 && line < len(t.lines) {
+		rows = countWraps(t.lines[line], textWidth)
+	}
 	if c := t.commentEndingAt(line); c != nil {
 		rows += commentDisplayRows(c.text)
 	}
@@ -235,20 +238,20 @@ func (t *tab) lineVisualRows(line int) int {
 
 // visualRowsBetween returns the total visual rows from line 'from'
 // to line 'to' inclusive.
-func (t *tab) visualRowsBetween(from, to int) int {
+func (t *tab) visualRowsBetween(from, to, textWidth int) int {
 	rows := 0
 	for i := from; i <= to && i < len(t.lines); i++ {
-		rows += t.lineVisualRows(i)
+		rows += t.lineVisualRows(i, textWidth)
 	}
 	return rows
 }
 
 // scrollOffsetFor finds the scroll offset (logical line) where targetLine
 // appears at approximately targetVisualRow from the top of the viewport.
-func (t *tab) scrollOffsetFor(targetLine, targetVisualRow int) int {
+func (t *tab) scrollOffsetFor(targetLine, targetVisualRow, textWidth int) int {
 	rows := 0
 	for i := targetLine; i >= 0; i-- {
-		rows += t.lineVisualRows(i)
+		rows += t.lineVisualRows(i, textWidth)
 		if rows >= targetVisualRow {
 			return i
 		}
@@ -258,6 +261,6 @@ func (t *tab) scrollOffsetFor(targetLine, targetVisualRow int) int {
 
 // maxScrollOffset returns the largest valid scrollOffset (logical line)
 // such that rendering from that line fills at least contentHeight visual rows.
-func (t *tab) maxScrollOffset(contentHeight int) int {
-	return t.scrollOffsetFor(len(t.lines)-1, contentHeight)
+func (t *tab) maxScrollOffset(contentHeight, textWidth int) int {
+	return t.scrollOffsetFor(len(t.lines)-1, contentHeight, textWidth)
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -228,6 +228,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			targetChar := max(editorX, 0)
+			if editorY >= 0 && editorY < len(m.lastMapping) {
+				targetChar += m.lastMapping[editorY].wrapOffset
+			}
 			if targetLine < len(t.lines) {
 				runeLen := len([]rune(t.lines[targetLine]))
 				if targetChar > runeLen {
@@ -279,7 +282,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case msg.Button == tea.MouseButtonWheelDown:
 				t.scrollOffset += scrollAmount
-				maxOffset := t.maxScrollOffset(lo.contentHeight)
+				maxOffset := t.maxScrollOffset(lo.contentHeight, lo.textWidth)
 				if t.scrollOffset > maxOffset {
 					t.scrollOffset = maxOffset
 				}
@@ -563,7 +566,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.focusPane == paneTree {
 		m.adjustTreeScroll(lo.contentHeight)
 	} else if hasTab && len(t.lines) > 0 {
-		t.adjustScrollForCursor(lo.contentHeight)
+		t.adjustScrollForCursor(lo.contentHeight, lo.textWidth)
 	}
 
 	return m, nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -254,6 +254,7 @@ func (m *Model) renderEditor(lo layout) []string {
 	width := lo.editorWidth
 	height := lo.contentHeight
 	lnw := lo.lineNumWidth
+	textWidth := lo.textWidth
 
 	lines := make([]string, 0, height)
 	var mapping []visualEntry
@@ -279,15 +280,18 @@ func (m *Model) renderEditor(lo layout) []string {
 	for i := offset; i < len(t.lines) && len(lines) < height; i++ {
 		lineContent := t.lines[i]
 
-		var sb strings.Builder
-
+		// Build line number prefix
+		var lnSB strings.Builder
 		if t.findComment(i) >= 0 {
-			sb.WriteString(styleComment.Render("\u258e"))
-			fmt.Fprintf(&sb, barFmt, i+1)
+			lnSB.WriteString(styleComment.Render("\u258e"))
+			fmt.Fprintf(&lnSB, barFmt, i+1)
 		} else {
-			fmt.Fprintf(&sb, normalFmt, i+1)
+			fmt.Fprintf(&lnSB, normalFmt, i+1)
 		}
+		lineNumStr := lnSB.String()
 
+		// Build content (without line number)
+		var contentSB strings.Builder
 		isCursorLine := m.focusPane == paneEditor && i == t.cursorLine
 		isSelected := m.focusPane == paneEditor && t.selecting && i >= startLine && i <= endLine
 
@@ -296,38 +300,65 @@ func (m *Model) renderEditor(lo layout) []string {
 			sc, ec := selRange(i, startLine, endLine, startChar, endChar, lineContent)
 			if sc == ec {
 				if hl := t.getHighlightedLine(i); hl != nil {
-					renderStyledLineWithCursor(&sb, hl.runs, t.cursorChar)
+					renderStyledLineWithCursor(&contentSB, hl.runs, t.cursorChar)
 				} else {
-					renderLineWithCursor(&sb, lineContent, t.cursorChar)
+					renderLineWithCursor(&contentSB, lineContent, t.cursorChar)
 				}
 			} else if hl := t.getHighlightedLine(i); hl != nil {
-				renderStyledLineWithSelection(&sb, hl.runs, sc, ec)
+				renderStyledLineWithSelection(&contentSB, hl.runs, sc, ec)
 			} else {
-				renderLineWithCursorAndSelection(&sb, lineContent, sc, ec)
+				renderLineWithCursorAndSelection(&contentSB, lineContent, sc, ec)
 			}
 		case isCursorLine:
 			if hl := t.getHighlightedLine(i); hl != nil {
-				renderStyledLineWithCursor(&sb, hl.runs, t.cursorChar)
+				renderStyledLineWithCursor(&contentSB, hl.runs, t.cursorChar)
 			} else {
-				renderLineWithCursor(&sb, lineContent, t.cursorChar)
+				renderLineWithCursor(&contentSB, lineContent, t.cursorChar)
 			}
 		case isSelected:
 			sc, ec := selRange(i, startLine, endLine, startChar, endChar, lineContent)
 			if hl := t.getHighlightedLine(i); hl != nil {
-				renderStyledLineWithSelection(&sb, hl.runs, sc, ec)
+				renderStyledLineWithSelection(&contentSB, hl.runs, sc, ec)
 			} else {
-				renderLineWithCursorAndSelection(&sb, lineContent, sc, ec)
+				renderLineWithCursorAndSelection(&contentSB, lineContent, sc, ec)
 			}
 		default:
 			if hl := t.getHighlightedLine(i); hl != nil {
-				sb.WriteString(hl.rendered)
+				contentSB.WriteString(hl.rendered)
 			} else {
-				sb.WriteString(expandTabs(lineContent))
+				contentSB.WriteString(expandTabs(lineContent))
 			}
 		}
 
-		lines = append(lines, sb.String())
-		mapping = append(mapping, visualEntry{logicalLine: i})
+		content := contentSB.String()
+
+		// Word wrap and emit visual rows
+		bp := wrapBreakpoints(lineContent, textWidth)
+		if bp != nil {
+			wrapped := ansi.Hardwrap(content, textWidth, true)
+			segments := strings.Split(wrapped, "\n")
+			for si, seg := range segments {
+				if len(lines) >= height {
+					break
+				}
+				wrapOff := 0
+				if si > 0 {
+					if si-1 < len(bp) {
+						wrapOff = bp[si-1]
+					}
+					lines = append(lines, lnPad+ansiReset+seg)
+				} else {
+					lines = append(lines, lineNumStr+seg)
+				}
+				mapping = append(mapping, visualEntry{
+					logicalLine: i,
+					wrapOffset:  wrapOff,
+				})
+			}
+		} else {
+			lines = append(lines, lineNumStr+content)
+			mapping = append(mapping, visualEntry{logicalLine: i})
+		}
 
 		if t.inputMode && i == t.inputEnd {
 			label := fmt.Sprintf("comment (%s: save, Esc: cancel)",


### PR DESCRIPTION
## Overview

Add word wrap for the editor pane.

## Why

When the terminal is narrow or lines are long, text overflows to the
right and becomes invisible. Wrapping lines at the editor width makes
all content visible.

## What

Wrapping is applied at the rendering layer only. The data model
(lines, cursorLine/Char, selection) is unchanged.

- Add `textWidth` field to `layout` struct (`editorWidth - lineNumWidth`)
- Add `wrapBreakpoints` / `countWraps` in `display.go` using
  `mattn/go-runewidth` for width calculation consistent with
  `ansi.Hardwrap`
- Add `wrapOffset` to `visualEntry` for correct mouse click mapping
  on continuation lines
- Thread `textWidth` through scroll calculation methods
  (`lineVisualRows`, `visualRowsBetween`, `scrollOffsetFor`,
  `maxScrollOffset`, `adjustScrollForCursor`)
- Separate line number prefix and content rendering in `renderEditor`;
  wrap content with `ansi.Hardwrap` and prepend `ansiReset` to
  continuation lines to prevent ANSI style leakage

## Type of Change

- [x] Feature

## How to Test

```bash
go test ./internal/tui/...
go build -o gra ./cmd/gra/
```

1. Launch `gra` and open a file containing lines longer than the
   terminal width
2. Verify long lines are automatically wrapped
3. Verify mouse click, scroll, and cursor movement work correctly
   on wrapped lines

## Checklist

- [x] Self-reviewed