### PR TITLE
refactor: migrate clipboard to Bubbletea v2 native API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	charm.land/bubbletea/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.0
 	github.com/alecthomas/chroma/v2 v2.23.1
-	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/epilande/go-devicons v0.0.0-20250505162540-0661cab71a28
 	github.com/fsnotify/fsnotify v1.9.0
@@ -19,6 +18,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -10,7 +10,6 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
-	"github.com/atotto/clipboard"
 )
 
 const (
@@ -515,15 +514,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Copy):
 			if hasTab && m.focusPane == paneEditor && t.selecting {
 				text := t.selectedText()
-				if err := clipboard.WriteAll(text); err != nil {
-					m.statusMsg = fmt.Sprintf("Copy failed: %v", err)
-				} else {
-					n := strings.Count(text, "\n") + 1
-					m.statusMsg = fmt.Sprintf("Copied %d lines", n)
-				}
-				return m, tea.Tick(statusClearTimeout, func(time.Time) tea.Msg {
-					return statusClearMsg{}
-				})
+				n := strings.Count(text, "\n") + 1
+				m.statusMsg = fmt.Sprintf("Copied %d lines", n)
+				return m, tea.Batch(
+					tea.SetClipboard(text),
+					tea.Tick(statusClearTimeout, func(time.Time) tea.Msg {
+						return statusClearMsg{}
+					}),
+				)
 			}
 		case key.Matches(msg, m.keys.ClearAll):
 			if hasTab && m.focusPane == paneEditor {


### PR DESCRIPTION
## Overview

Migrate clipboard operations from external library to Bubbletea v2 native API.

## Why

`github.com/atotto/clipboard` only works in local environments and cannot be used over SSH. Bubbletea v2 provides `tea.SetClipboard()` which is OSC52-based and works over SSH, while also reducing external dependencies.

## What

- Replace `clipboard.WriteAll()` with `tea.SetClipboard()`
- Remove direct dependency on `github.com/atotto/clipboard` (remains as indirect via `bubbles/v2/textarea`)
- Remove error handling path since OSC52 is asynchronous and always show status message

## Type of Change

- [x] Refactoring

## How to Test

```bash
go build -o gra ./cmd/gra/
go test ./...
```

1. Launch `gra` and open a file
2. Enter selection mode with `v` and select a range
3. Press `y` to copy
4. Verify "Copied N lines" appears in the status bar
5. Paste in another application and confirm the content is correct

## Checklist

- [x] Self-reviewed