### PR TITLE
feat: set terminal window title via tea.View.WindowTitle

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -41,7 +41,8 @@ func newView(content, title string) tea.View {
 
 // View implements tea.Model.
 func (m *Model) View() tea.View {
-	title := fmt.Sprintf("gracilius - Port %d", m.server.Port())
+	project := filepath.Base(m.rootDir)
+	title := fmt.Sprintf("gracilius - %s", project)
 
 	if m.err != nil {
 		return newView(fmt.Sprintf("Error: %v\n\nPress Ctrl+C to quit.", m.err), title)
@@ -54,10 +55,10 @@ func (m *Model) View() tea.View {
 	t, hasTab := m.activeTabState()
 
 	// header
-	header := title
+	header := fmt.Sprintf("gracilius - Port %d", m.server.Port())
 	if hasTab && t.filePath != "" {
 		header += fmt.Sprintf(" | %s", t.filePath)
-		title = fmt.Sprintf("gracilius - %s", filepath.Base(t.filePath))
+		title = fmt.Sprintf("gracilius - %s - %s", project, filepath.Base(t.filePath))
 	}
 	// content
 	lo := m.computeLayout()


### PR DESCRIPTION
## Overview

Bubbletea v2 の `tea.View.WindowTitle` フィールドを使用して、ターミナルのウィンドウタイトルにプロジェクト名とファイル名を表示する。

## Why

ターミナルのウィンドウタイトルに現在の状態を表示することで、複数のターミナルタブ/ウィンドウを使用する際にどの gracilius セッションかを識別しやすくする。

## What

- `newView` 関数に `title` 引数を追加し、`tea.View.WindowTitle` を設定
- `View()` メソッド内でウィンドウタイトルを計算
  - デフォルト: `gracilius - {project}`
  - ファイルが開いている場合: `gracilius - {project} - {filename}`
- プロジェクト名は `filepath.Base(m.rootDir)` から取得

## Type of Change

- [x] Feature

## How to Test

1. `go run ./cmd/gra/` で起動
2. ターミナルのウィンドウタイトル/タブに `gracilius - {project}` と表示されることを確認
3. ファイルを開くと `gracilius - {project} - {filename}` に変わることを確認

## Checklist

- [x] Self-reviewed