### PR TITLE
refactor: migrate editor scroll and gutter to Bubbles v2 Viewport

### DIFF
--- a/internal/tui/fileio.go
+++ b/internal/tui/fileio.go
@@ -66,6 +66,7 @@ func (m *Model) loadFileIntoTab(t *tab, filePath string) error {
 	}
 
 	t.lines = splitLines(content)
+	t.syncContent(t.lines)
 	t.highlightedLines = highlightFile(absPath, string(content), m.theme)
 
 	return nil

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/viewport"
 )
 
 // tabKind distinguishes between file and diff tabs.
@@ -34,7 +36,7 @@ type tab struct {
 	anchorChar       int
 	selecting        bool
 	lineSelect       bool
-	scrollOffset     int
+	vp               viewport.Model
 
 	comments     []comment
 	commentInput textarea.Model
@@ -61,11 +63,20 @@ func newTextarea() textarea.Model {
 	return ta
 }
 
+// newViewport creates a viewport with keybindings disabled.
+func newViewport() viewport.Model {
+	vp := viewport.New()
+	vp.KeyMap = viewport.KeyMap{} // disable all keybindings
+	vp.MouseWheelEnabled = true
+	return vp
+}
+
 // newFileTab creates a new tab for file viewing.
 func newFileTab() *tab {
 	return &tab{
 		kind:         fileTab,
 		commentInput: newTextarea(),
+		vp:           newViewport(),
 	}
 }
 
@@ -76,11 +87,37 @@ func newDiffTab(filePath string, lines []string, onAccept func(string), onReject
 		filePath:     filePath,
 		lines:        lines,
 		commentInput: newTextarea(),
+		vp:           newViewport(),
 		diff: &diffState{
 			onAccept: onAccept,
 			onReject: onReject,
 		},
 	}
+}
+
+// configureGutter sets up the LeftGutterFunc for line numbers
+// with comment markers.
+func (t *tab) configureGutter(digitWidth int) {
+	softPad := strings.Repeat(" ", digitWidth+2)
+	t.vp.LeftGutterFunc = func(ctx viewport.GutterContext) string {
+		if ctx.Soft || ctx.Index >= ctx.TotalLines {
+			return softPad
+		}
+		var sb strings.Builder
+		if t.findComment(ctx.Index) >= 0 {
+			sb.WriteString(styleComment.Render("\u258e"))
+			fmt.Fprintf(&sb, "%*d ", digitWidth, ctx.Index+1)
+		} else {
+			fmt.Fprintf(&sb, " %*d ", digitWidth, ctx.Index+1)
+		}
+		return sb.String()
+	}
+}
+
+// syncContent updates the viewport content and reconfigures the gutter.
+func (t *tab) syncContent(lines []string) {
+	t.vp.SetContentLines(lines)
+	t.configureGutter(lineNumWidthFor(len(lines)) - 2)
 }
 
 // rejectAndClear calls onReject if set and nils the diff state.
@@ -208,7 +245,7 @@ func (t *tab) resetEditorState() {
 	t.cursorChar = 0
 	t.anchorLine = 0
 	t.anchorChar = 0
-	t.scrollOffset = 0
+	t.vp.SetYOffset(0)
 	t.selecting = false
 	t.lineSelect = false
 	t.comments = nil
@@ -222,21 +259,18 @@ func (t *tab) adjustScrollForCursor(contentHeight, textWidth int) {
 	margin := contentHeight / 5
 
 	// Cursor above visible area (logical check is sufficient)
-	if t.cursorLine < t.scrollOffset+margin {
-		t.scrollOffset = t.cursorLine - margin
+	if t.cursorLine < t.vp.YOffset()+margin {
+		t.vp.SetYOffset(t.cursorLine - margin)
 	}
 
 	// Cursor below visible area (visual-row aware)
-	if t.visualRowsBetween(t.scrollOffset, t.cursorLine, textWidth) > contentHeight-margin {
-		t.scrollOffset = t.scrollOffsetFor(t.cursorLine, contentHeight-margin, textWidth)
+	if t.visualRowsBetween(t.vp.YOffset(), t.cursorLine, textWidth) > contentHeight-margin {
+		t.vp.SetYOffset(t.scrollOffsetFor(t.cursorLine, contentHeight-margin, textWidth))
 	}
 
 	maxOffset := t.maxScrollOffset(contentHeight, textWidth)
-	if t.scrollOffset > maxOffset {
-		t.scrollOffset = maxOffset
-	}
-	if t.scrollOffset < 0 {
-		t.scrollOffset = 0
+	if t.vp.YOffset() > maxOffset {
+		t.vp.SetYOffset(maxOffset)
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	scrollAmount       = 3
 	quitTimeout        = 750 * time.Millisecond
 	statusClearTimeout = 2 * time.Second
 )
@@ -130,6 +129,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fileChangedMsg:
 		if hasTab {
 			t.lines = msg.lines
+			t.syncContent(msg.lines)
 			t.highlightedLines = highlightFile(
 				t.filePath, strings.Join(msg.lines, "\n"), m.theme,
 			)
@@ -155,6 +155,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case OpenDiffMsg:
 		lines := splitLines([]byte(msg.Contents))
 		dt := newDiffTab(msg.FilePath, lines, msg.Accept, msg.Reject)
+		dt.syncContent(lines)
 		dt.highlightedLines = highlightFile(msg.FilePath, msg.Contents, m.theme)
 		m.tabs = append(m.tabs, dt)
 		m.activeTab = len(m.tabs) - 1
@@ -180,6 +181,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		maxWidth := m.width * maxTreeWidthPercent / 100
 		if m.treeWidth > maxWidth {
 			m.treeWidth = maxWidth
+		}
+		lo := m.computeLayout()
+		for _, tab := range m.tabs {
+			tab.vp.SetWidth(lo.editorWidth)
+			tab.vp.SetHeight(lo.contentHeight)
 		}
 		if hasTab && t.filePath != "" && len(t.lines) > 0 && m.focusPane == paneEditor {
 			m.notifySelectionChanged()
@@ -292,18 +298,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		lo := m.computeLayout()
 		if msg.X >= lo.editorStartX && msg.Y >= contentStartY {
-			switch msg.Button {
-			case tea.MouseWheelUp:
-				t.scrollOffset -= scrollAmount
-				if t.scrollOffset < 0 {
-					t.scrollOffset = 0
-				}
-			case tea.MouseWheelDown:
-				t.scrollOffset += scrollAmount
-				maxOffset := t.maxScrollOffset(lo.contentHeight, lo.textWidth)
-				if t.scrollOffset > maxOffset {
-					t.scrollOffset = maxOffset
-				}
+			t.vp, _ = t.vp.Update(msg)
+			maxOff := t.maxScrollOffset(lo.contentHeight, lo.textWidth)
+			if t.vp.YOffset() > maxOff {
+				t.vp.SetYOffset(maxOff)
 			}
 		}
 		return m, nil
@@ -611,7 +609,7 @@ func (m *Model) editorTarget(t *tab, lo layout, mouseX, mouseY int) (int, int) {
 	editorX := mouseX - lo.editorStartX - lo.lineNumWidth
 	editorY := mouseY - contentStartY
 
-	targetLine := t.scrollOffset + editorY
+	targetLine := t.vp.YOffset() + editorY
 	if editorY >= 0 && editorY < len(m.lastMapping) {
 		targetLine = m.lastMapping[editorY].logicalLine
 	}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -284,25 +285,18 @@ func (m *Model) renderEditor(lo layout) []string {
 
 	startLine, startChar, endLine, endChar := t.normalizedSelection()
 	selBgSeq := m.theme.selectionBgSeq()
-	offset := t.scrollOffset
+	offset := t.vp.YOffset()
 	commentBodyWidth := width - lnw - commentBlockMargin
-	lnPad := strings.Repeat(" ", lnw)
-	digitWidth := lnw - 2 // subtract marker and trailing space
-	normalFmt := fmt.Sprintf(" %%%dd ", digitWidth)
-	barFmt := fmt.Sprintf("%%%dd ", digitWidth)
+	total := len(t.lines)
+	gutterCtx := viewport.GutterContext{TotalLines: total}
 
 	for i := offset; i < len(t.lines) && len(lines) < height; i++ {
 		lineContent := t.lines[i]
 
-		// Build line number prefix
-		var lnSB strings.Builder
-		if t.findComment(i) >= 0 {
-			lnSB.WriteString(styleComment.Render("\u258e"))
-			fmt.Fprintf(&lnSB, barFmt, i+1)
-		} else {
-			fmt.Fprintf(&lnSB, normalFmt, i+1)
-		}
-		lineNumStr := lnSB.String()
+		// Build line number prefix via LeftGutterFunc
+		gutterCtx.Index = i
+		gutterCtx.Soft = false
+		lineNumStr := t.vp.LeftGutterFunc(gutterCtx)
 
 		// Build content and emit visual rows
 		isCursorLine := m.focusPane == paneEditor && i == t.cursorLine
@@ -374,6 +368,8 @@ func (m *Model) renderEditor(lo layout) []string {
 
 				seg := segSB.String()
 				if si > 0 {
+					gutterCtx.Soft = true
+					lnPad := t.vp.LeftGutterFunc(gutterCtx)
 					lines = append(lines, padRight(lnPad+seg+ansiReset, width))
 				} else {
 					lines = append(lines, padRight(lineNumStr+seg+ansiReset, width))
@@ -428,6 +424,8 @@ func (m *Model) renderEditor(lo layout) []string {
 		}
 
 		if t.inputMode && i == t.inputEnd {
+			gutterCtx.Soft = true
+			lnPad := t.vp.LeftGutterFunc(gutterCtx)
 			label := fmt.Sprintf("comment (%s: save, Esc: cancel)",
 				m.keys.CommentSubmit.Help().Key)
 			blockRows := renderBlock(
@@ -441,6 +439,8 @@ func (m *Model) renderEditor(lo layout) []string {
 					visualEntry{logicalLine: i, kind: lineKindInput})
 			}
 		} else if c := t.commentEndingAt(i); c != nil {
+			gutterCtx.Soft = true
+			lnPad := t.vp.LeftGutterFunc(gutterCtx)
 			label := formatCommentLabel(c)
 			blockRows := renderBlock(
 				c.text, label, commentBodyWidth, styleComment, styleBodyWhite)


### PR DESCRIPTION
## Overview

Migrate editor pane scroll management and line number gutter rendering to Bubbles v2 Viewport component.

## Why

Replace the manual `scrollOffset` field and inline line-number construction with Viewport v2 APIs, improving scroll management reliability and code maintainability.

## What

- Replace `tab.scrollOffset int` with `tab.vp viewport.Model`
- Implement line number + comment marker gutter via `LeftGutterFunc` closure
- Delegate mouse wheel handling to `viewport.Update()` with custom maxOffset clamping for comment blocks and word-wrap
- Sync viewport dimensions for all tabs on `WindowSizeMsg`
- Extract `syncContent` helper to eliminate `SetContentLines` + gutter setup duplication
- Pre-compute soft gutter padding to avoid `strings.Repeat` recomputation in render loop

### Constraints

Rendering delegation via `viewport.View()` is not possible due to cursor/selection ANSI overlay, variable-height comment block insertion, and visual row mapping dependency for mouse coordinate translation. Custom `renderEditor` is retained.

### Changed Files

| File | Changes |
| --- | --- |
| `internal/tui/tab.go` | Add `vp` field, remove `scrollOffset`, add `configureGutter` / `syncContent`, update scroll methods |
| `internal/tui/view.go` | Replace inline gutter with `LeftGutterFunc` calls, use `vp.YOffset()` for offset |
| `internal/tui/update.go` | Delegate mouse wheel, sync vp dimensions on resize, sync content |
| `internal/tui/fileio.go` | Call `syncContent` on file load |

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [x] Performance
- [ ] Other

## How to Test

1. Verify build and tests pass: `go build ./cmd/gra/ && go test ./...`
2. Launch `gra`, select a file — line numbers should display correctly
3. Lines with comments should show the "▎" marker
4. Mouse wheel scrolling should work
5. Cursor movement with j/k should scroll to follow
6. G/gg should jump to bottom/top
7. Word-wrapped line continuations should have correct gutter padding
8. Terminal resize should work correctly

## Checklist

- [x] Self-reviewed