### PR TITLE
feat: add scrollbar to file tree and editor panes

### DIFF
--- a/internal/tui/highlight.go
+++ b/internal/tui/highlight.go
@@ -22,6 +22,7 @@ type themeConfig struct {
 	openFileMatchFg     string // Fuzzy match highlight fg
 	logoLeaf            string // Welcome logo top color (green/leaf)
 	logoTrunk           string // Welcome logo bottom color (brown/trunk)
+	scrollbarThumbFg    string // Scrollbar thumb foreground hex color
 }
 
 func (t themeConfig) selectionBgSeq() string {
@@ -41,6 +42,7 @@ var (
 		openFileMatchFg:     "#FFCC66",
 		logoLeaf:            "#73C991",
 		logoTrunk:           "#CE9178",
+		scrollbarThumbFg:    "#424242",
 	}
 	lightTheme = themeConfig{
 		name:                "github",
@@ -54,6 +56,7 @@ var (
 		openFileMatchFg:     "#0066CC",
 		logoLeaf:            "#1B7F37",
 		logoTrunk:           "#795E26",
+		scrollbarThumbFg:    "#C0C0C0",
 	}
 )
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -35,10 +35,10 @@ const (
 //
 // Horizontal:
 //
-//	|<-treeWidth->|<sep>|<----editorWidth-------->|
-//	|             | (3) |<-lnw->|<----text------->|
-//	              ^             ^
-//	              editorStartX  editorStartX + lineNumberWidth
+//	|<-treeWidth->|<sep>|<-------editorWidth---------->|
+//	|          |sb| (3) |<-lnw->|<----text------->|sb|
+//	           ^  ^             ^                  ^
+//	     scrollbar editorStartX  lineNumWidth   scrollbar
 type layout struct {
 	contentHeight int // usable rows for tree and editor panes
 	treeWidth     int // file tree pane width
@@ -92,6 +92,6 @@ func (m *Model) computeLayout() layout {
 		editorStartX:  tw + separatorWidth,
 		editorWidth:   ew,
 		lineNumWidth:  lnw,
-		textWidth:     ew - lnw,
+		textWidth:     ew - lnw - scrollbarWidth,
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -104,8 +104,9 @@ type Model struct {
 	openFile openFileOverlay
 
 	// theme
-	isDark bool
-	theme  themeConfig
+	isDark         bool
+	theme          themeConfig
+	scrollbarBlock string // cached styled thumb character
 }
 
 // lineKind distinguishes the type of a visual row.
@@ -202,20 +203,21 @@ func NewModel(srv MCPServer, rootDir string, watcher *fsnotify.Watcher, dirWatch
 
 	im := detectIconMode()
 	return &Model{
-		server:     srv,
-		rootDir:    absRootDir,
-		fileTree:   ft,
-		treeCursor: 0,
-		focusPane:  paneTree,
-		watcher:    watcher,
-		dirWatcher: dirWatcher,
-		tabs:       []*tab{},
-		treeWidth:  30,
-		keys:       newKeyMap(),
-		help:       help.New(),
-		iconMode:   im,
-		openFile:   newOpenFileOverlay(im, darkTheme),
-		isDark:     true,
-		theme:      darkTheme,
+		server:         srv,
+		rootDir:        absRootDir,
+		fileTree:       ft,
+		treeCursor:     0,
+		focusPane:      paneTree,
+		watcher:        watcher,
+		dirWatcher:     dirWatcher,
+		tabs:           []*tab{},
+		treeWidth:      30,
+		keys:           newKeyMap(),
+		help:           help.New(),
+		iconMode:       im,
+		openFile:       newOpenFileOverlay(im, darkTheme),
+		isDark:         true,
+		theme:          darkTheme,
+		scrollbarBlock: scrollbarBlock(darkTheme.scrollbarThumbFg),
 	}, nil
 }

--- a/internal/tui/scrollbar.go
+++ b/internal/tui/scrollbar.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"charm.land/lipgloss/v2"
+)
+
+const scrollbarWidth = 1
+
+// scrollbarBlock returns the styled thumb character for the given color.
+func scrollbarBlock(fgColor string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(fgColor)).Render("\u2588")
+}
+
+// renderScrollbar generates a column of scrollbar characters.
+// Each element is a single-character string: either a styled thumb block
+// or a space (track). When totalItems <= height, all entries are spaces.
+func renderScrollbar(height, totalItems, offset int, block string) []string {
+	col := make([]string, height)
+	for i := range col {
+		col[i] = " "
+	}
+
+	if totalItems <= height || height <= 0 {
+		return col
+	}
+
+	thumbSize := max(1, height*height/totalItems)
+	maxOffset := totalItems - height
+	thumbPos := 0
+	if maxOffset > 0 {
+		thumbPos = offset * (height - thumbSize) / maxOffset
+	}
+
+	for i := thumbPos; i < thumbPos+thumbSize && i < height; i++ {
+		col[i] = block
+	}
+
+	return col
+}
+
+// appendScrollbar appends scrollbar column entries to each line.
+func appendScrollbar(lines []string, scrollbar []string) {
+	for i := range lines {
+		lines[i] += scrollbar[i]
+	}
+}

--- a/internal/tui/scrollbar_test.go
+++ b/internal/tui/scrollbar_test.go
@@ -1,0 +1,53 @@
+package tui
+
+import (
+	"testing"
+)
+
+const testBlock = "\u2588"
+
+func TestRenderScrollbar_AllVisible(t *testing.T) {
+	col := renderScrollbar(10, 5, 0, testBlock)
+	for i, c := range col {
+		if c != " " {
+			t.Errorf("row %d: expected space, got %q", i, c)
+		}
+	}
+}
+
+func TestRenderScrollbar_OffsetZero(t *testing.T) {
+	col := renderScrollbar(10, 100, 0, testBlock)
+	if col[0] == " " {
+		t.Error("expected thumb at row 0 when offset=0")
+	}
+}
+
+func TestRenderScrollbar_OffsetMax(t *testing.T) {
+	height := 10
+	total := 100
+	maxOffset := total - height
+	col := renderScrollbar(height, total, maxOffset, testBlock)
+	if col[height-1] == " " {
+		t.Errorf("expected thumb at last row when offset=max")
+	}
+}
+
+func TestRenderScrollbar_ZeroTotal(t *testing.T) {
+	col := renderScrollbar(10, 0, 0, testBlock)
+	if len(col) != 10 {
+		t.Errorf("expected 10 rows, got %d", len(col))
+	}
+}
+
+func TestRenderScrollbar_ThumbMinSize(t *testing.T) {
+	col := renderScrollbar(5, 10000, 0, testBlock)
+	thumbCount := 0
+	for _, c := range col {
+		if c != " " {
+			thumbCount++
+		}
+	}
+	if thumbCount < 1 {
+		t.Error("thumb size should be at least 1")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -117,6 +117,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.theme = lightTheme
 		}
+		m.scrollbarBlock = scrollbarBlock(m.theme.scrollbarThumbFg)
 		m.help.Styles = help.DefaultStyles(m.isDark)
 		m.openFile.updateTheme(m.theme)
 		for _, tab := range m.tabs {
@@ -287,10 +288,26 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.openFile.active {
 			return m, nil
 		}
+		lo := m.computeLayout()
+		if msg.X < lo.treeWidth && msg.Y >= contentStartY {
+			switch msg.Button {
+			case tea.MouseWheelUp:
+				m.treeScrollOffset -= scrollAmount
+				if m.treeScrollOffset < 0 {
+					m.treeScrollOffset = 0
+				}
+			case tea.MouseWheelDown:
+				m.treeScrollOffset += scrollAmount
+				maxOff := max(len(m.fileTree)-lo.contentHeight, 0)
+				if m.treeScrollOffset > maxOff {
+					m.treeScrollOffset = maxOff
+				}
+			}
+			return m, nil
+		}
 		if !hasTab || len(t.lines) == 0 {
 			return m, nil
 		}
-		lo := m.computeLayout()
 		if msg.X >= lo.editorStartX && msg.Y >= contentStartY {
 			switch msg.Button {
 			case tea.MouseWheelUp:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -210,6 +210,7 @@ func (m *Model) renderFooter() string {
 // renderTree generates the tree pane lines.
 func (m *Model) renderTree(width, height int) []string {
 	lines := make([]string, 0, height)
+	contentWidth := width - scrollbarWidth
 
 	var activeFilePath string
 	if t, ok := m.activeTabState(); ok {
@@ -237,8 +238,8 @@ func (m *Model) renderTree(width, height int) []string {
 		icon := iconFor(m.iconMode, entry)
 
 		line := indent + arrow + icon.prefix() + entry.name
-		displayLine := ansi.Truncate(line, width, "...")
-		displayLine = padRight(displayLine, width)
+		displayLine := ansi.Truncate(line, contentWidth, "...")
+		displayLine = padRight(displayLine, contentWidth)
 
 		switch {
 		case isCursor:
@@ -255,8 +256,10 @@ func (m *Model) renderTree(width, height int) []string {
 	}
 
 	for len(lines) < height {
-		lines = append(lines, padRight("", width))
+		lines = append(lines, padRight("", contentWidth))
 	}
+
+	appendScrollbar(lines, renderScrollbar(height, len(m.fileTree), m.treeScrollOffset, m.scrollbarBlock))
 
 	return lines
 }
@@ -268,16 +271,18 @@ func (m *Model) renderEditor(lo layout) []string {
 	height := lo.contentHeight
 	lnw := lo.lineNumWidth
 	textWidth := lo.textWidth
+	contentWidth := width - scrollbarWidth
 
 	lines := make([]string, 0, height)
 	var mapping []visualEntry
 
 	if !hasTab || len(t.lines) == 0 {
 		emptyMsg := emptyStateMsg
-		lines = append(lines, padRight(emptyMsg, width))
+		lines = append(lines, padRight(emptyMsg, contentWidth))
 		for len(lines) < height {
-			lines = append(lines, padRight("", width))
+			lines = append(lines, padRight("", contentWidth))
 		}
+		appendScrollbar(lines, renderScrollbar(height, 0, 0, m.scrollbarBlock))
 		m.lastMapping = nil
 		return lines
 	}
@@ -374,9 +379,9 @@ func (m *Model) renderEditor(lo layout) []string {
 
 				seg := segSB.String()
 				if si > 0 {
-					lines = append(lines, padRight(lnPad+seg+ansiReset, width))
+					lines = append(lines, padRight(lnPad+seg+ansiReset, contentWidth))
 				} else {
-					lines = append(lines, padRight(lineNumStr+seg+ansiReset, width))
+					lines = append(lines, padRight(lineNumStr+seg+ansiReset, contentWidth))
 				}
 				mapping = append(mapping, visualEntry{
 					logicalLine: i,
@@ -423,7 +428,7 @@ func (m *Model) renderEditor(lo layout) []string {
 			}
 
 			content := contentSB.String()
-			lines = append(lines, padRight(lineNumStr+content+ansiReset, width))
+			lines = append(lines, padRight(lineNumStr+content+ansiReset, contentWidth))
 			mapping = append(mapping, visualEntry{logicalLine: i})
 		}
 
@@ -436,7 +441,7 @@ func (m *Model) renderEditor(lo layout) []string {
 				if len(lines) >= height {
 					break
 				}
-				lines = append(lines, lnPad+r)
+				lines = append(lines, padRight(lnPad+r, contentWidth))
 				mapping = append(mapping,
 					visualEntry{logicalLine: i, kind: lineKindInput})
 			}
@@ -448,7 +453,7 @@ func (m *Model) renderEditor(lo layout) []string {
 				if len(lines) >= height {
 					break
 				}
-				lines = append(lines, lnPad+r)
+				lines = append(lines, padRight(lnPad+r, contentWidth))
 				mapping = append(mapping,
 					visualEntry{logicalLine: i, kind: lineKindComment})
 			}
@@ -456,8 +461,10 @@ func (m *Model) renderEditor(lo layout) []string {
 	}
 
 	for len(lines) < height {
-		lines = append(lines, padRight("", width))
+		lines = append(lines, padRight("", contentWidth))
 	}
+
+	appendScrollbar(lines, renderScrollbar(height, len(t.lines), t.scrollOffset, m.scrollbarBlock))
 
 	m.lastMapping = mapping
 	return lines


### PR DESCRIPTION
## Overview

filetree ペインと editor ペインにスクロールバーを追加する。

## Why

コンテンツがビューポートを超える場合にスクロール位置が
視覚的に分からず、現在の表示位置を把握しづらかった。
また、ツリーペインではマウスホイールスクロールが未実装だった。

## What

- `scrollbar.go` を新規作成し、スクロールバー描画ロジックを実装
  - `renderScrollbar()`: thumb 位置とサイズを計算し列を生成
  - `appendScrollbar()`: 各行末尾にスクロールバー文字を結合
  - `scrollbarBlock()`: スタイル済み thumb 文字を生成
- 両ペインの右端 1 文字をスクロールバー用に常時確保
  （表示切替によるレイアウトジャンプを防止）
- コンテンツが収まる場合は thumb 非表示（track のみ = 空白）
- `themeConfig` に `scrollbarThumbFg` を追加
  （dark: `#424242`, light: `#C0C0C0`）
- `Model` にスタイル済み thumb 文字をキャッシュし
  レンダーごとの `lipgloss.NewStyle()` 呼び出しを回避
- ツリーペインのマウスホイールスクロールを実装
- `layout.textWidth` 計算を `scrollbarWidth` 分調整

## Type of Change

- [x] Feature

## How to Test

```bash
go test ./...
go build -o gra ./cmd/gra/
./gra
```

1. ファイルツリーにビューポートを超えるエントリがある状態で
   スクロールバー thumb が表示されることを確認
2. エディタでビューポートを超えるファイルを開き
   スクロールバー thumb が表示されることを確認
3. マウスホイールでツリーペインがスクロールすることを確認
4. コンテンツが収まる場合に thumb が非表示であることを確認
5. ダークテーマ / ライトテーマ切替で thumb 色が変わることを確認

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed