### PR TITLE
fix: preserve file tree expansion state on directory change

### DIFF
--- a/internal/tui/filetree.go
+++ b/internal/tui/filetree.go
@@ -144,6 +144,29 @@ func scanDir(dir string, depth int, entries []fileEntry) []fileEntry {
 	return entries
 }
 
+// expandedPaths returns the set of currently expanded directory paths.
+func expandedPaths(entries []fileEntry) map[string]bool {
+	paths := make(map[string]bool)
+	for _, e := range entries {
+		if e.isDir && e.expanded {
+			paths[e.path] = true
+		}
+	}
+	return paths
+}
+
+// restoreExpanded expands directories whose paths are in the given set.
+func restoreExpanded(
+	entries []fileEntry, paths map[string]bool,
+) []fileEntry {
+	for i := 0; i < len(entries); i++ {
+		if entries[i].isDir && paths[entries[i].path] {
+			entries = expandDir(entries, i)
+		}
+	}
+	return entries
+}
+
 // expandDir expands a directory entry and inserts its children.
 func expandDir(entries []fileEntry, index int) []fileEntry {
 	if index < 0 || index >= len(entries) || !entries[index].isDir {

--- a/internal/tui/update_msg.go
+++ b/internal/tui/update_msg.go
@@ -31,7 +31,9 @@ func (m *Model) handleFileChanged(msg fileChangedMsg) (tea.Model, tea.Cmd) {
 
 // handleTreeChanged processes directory tree change notifications.
 func (m *Model) handleTreeChanged() (tea.Model, tea.Cmd) {
+	expanded := expandedPaths(m.fileTree)
 	m.fileTree = buildFileTree(m.rootDir)
+	m.fileTree = restoreExpanded(m.fileTree, expanded)
 	if m.treeCursor >= len(m.fileTree) {
 		m.treeCursor = max(0, len(m.fileTree)-1)
 	}


### PR DESCRIPTION
## Overview

Fix file tree expansion state being lost on directory change.

## Why

Expanded directories in the file tree collapse whenever a file is
modified. Many editors perform atomic writes (write to temp file
then rename), which triggers Rename/Create events on the directory
watcher, firing `treeChangedMsg`.

`handleTreeChanged()` called `buildFileTree()` to rebuild the
entire tree from scratch, and new `fileEntry` values are always
created with `expanded: false`, losing all expansion state.

## What

Capture the set of expanded directory paths before rebuilding,
then re-expand them after the tree is reconstructed.

- `expandedPaths()`: collect currently expanded directory paths
- `restoreExpanded()`: re-expand directories matching the saved paths
- `handleTreeChanged()`: use the above to preserve expansion state

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Run `go test ./internal/tui/...` to verify tests pass
2. Launch TUI with `go run ./cmd/gra/`
3. Expand directories in the file tree
4. Modify and save a file inside an expanded directory with an external editor
5. Confirm the file tree expansion state is preserved

## Checklist

- [x] Self-reviewed
