### PR TITLE
chore: add .mcp.json for Claude Code MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gracilius": {
+      "command": "gra",
+      "args": ["mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Add `.mcp.json` to the repository root so that Claude Code can discover and use the gracilius MCP server.

## Why

The `.mcp.json` configuration file was not included when the MCP server feature was added in #44 . Without this file, Claude Code cannot automatically discover the gracilius MCP server.

## What

- Add `.mcp.json` with gracilius MCP server configuration
- Uses the installed `gra` binary with `mcp` subcommand

## Related

- #44

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [x] Other

## How to Test

1. Open a project with Claude Code
2. Verify that gracilius MCP server is listed in available MCP servers

## Checklist

- [x] Self-reviewed