### PR TITLE
feat: add tab click to switch active tab

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -7,6 +7,7 @@ const (
 	footerHeight        = 4 // border-top + help + status
 	separatorWidth      = 3
 	minLineNumberWidth  = 4
+	tabSeparatorWidth   = 1 // " " between tab labels
 	minTreeWidth        = 15
 	defaultTreePercent  = 30
 	maxTreeWidthPercent = 70

--- a/internal/tui/update_mouse.go
+++ b/internal/tui/update_mouse.go
@@ -6,6 +6,24 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
+// tabIndexAtX returns the tab index at screen X coordinate, or -1 if none.
+func (m *Model) tabIndexAtX(x int) int {
+	lo := m.computeLayout()
+	pos := lo.editorStartX
+	for i, t := range m.tabs {
+		if i > 0 {
+			pos += tabSeparatorWidth
+		}
+		label := tabLabel(t)
+		w := len([]rune(label))
+		if x >= pos && x < pos+w {
+			return i
+		}
+		pos += w
+	}
+	return -1
+}
+
 // handleMouseClick handles mouse click events.
 func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	t, hasTab := m.activeTabState()
@@ -20,6 +38,14 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 			} else if closeOverlay {
 				m.openFile.close()
 			}
+		}
+		return m, nil
+	}
+
+	if msg.Button == tea.MouseLeft &&
+		msg.Y >= headerHeight && msg.Y < headerHeight+tabBarHeight {
+		if idx := m.tabIndexAtX(msg.X); idx >= 0 {
+			m.activeTab = idx
 		}
 		return m, nil
 	}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -395,6 +395,95 @@ func TestContextKeyMap_DiffReviewBindings(t *testing.T) {
 	}
 }
 
+func TestTabIndexAtX(t *testing.T) {
+	m := newTestModel(t)
+
+	// No tabs: always -1.
+	if got := m.tabIndexAtX(40); got != -1 {
+		t.Errorf("no tabs: expected -1, got %d", got)
+	}
+
+	// Add two tabs.
+	t1 := newFileTab()
+	t1.filePath = "/workspace/main.go"
+	t2 := newFileTab()
+	t2.filePath = "/workspace/util.go"
+	m.tabs = []*tab{t1, t2}
+
+	lo := m.computeLayout()
+	// Tab 0 label: " main.go " (9 runes), starts at editorStartX.
+	label0 := tabLabel(t1)
+	w0 := len([]rune(label0))
+
+	// Click on first tab start.
+	if got := m.tabIndexAtX(lo.editorStartX); got != 0 {
+		t.Errorf("first tab start: expected 0, got %d", got)
+	}
+	// Click on first tab end - 1.
+	if got := m.tabIndexAtX(lo.editorStartX + w0 - 1); got != 0 {
+		t.Errorf("first tab end-1: expected 0, got %d", got)
+	}
+
+	// Second tab starts at editorStartX + w0 + 1 (separator).
+	secondStart := lo.editorStartX + w0 + 1
+	if got := m.tabIndexAtX(secondStart); got != 1 {
+		t.Errorf("second tab start: expected 1, got %d", got)
+	}
+
+	// Click before tabs.
+	if got := m.tabIndexAtX(0); got != -1 {
+		t.Errorf("before tabs: expected -1, got %d", got)
+	}
+
+	// Click after all tabs.
+	label1 := tabLabel(t2)
+	w1 := len([]rune(label1))
+	afterAll := secondStart + w1
+	if got := m.tabIndexAtX(afterAll); got != -1 {
+		t.Errorf("after all tabs: expected -1, got %d", got)
+	}
+}
+
+func TestMouseClick_TabBar(t *testing.T) {
+	m := newTestModel(t)
+
+	t1 := newFileTab()
+	t1.filePath = "/workspace/main.go"
+	t1.lines = []string{"package main"}
+	t2 := newFileTab()
+	t2.filePath = "/workspace/util.go"
+	t2.lines = []string{"package util"}
+	m.tabs = []*tab{t1, t2}
+	m.activeTab = 0
+
+	lo := m.computeLayout()
+	label0 := tabLabel(t1)
+	w0 := len([]rune(label0))
+	secondTabX := lo.editorStartX + w0 + 1
+
+	// Click on second tab (Y = headerHeight, the label row).
+	m.Update(tea.MouseClickMsg{
+		X:      secondTabX,
+		Y:      headerHeight,
+		Button: tea.MouseLeft,
+	})
+
+	if m.activeTab != 1 {
+		t.Errorf("expected activeTab=1 after click, got %d", m.activeTab)
+	}
+
+	// Click on first tab (Y = headerHeight+1, the underline row).
+	m.Update(tea.MouseClickMsg{
+		X:      lo.editorStartX,
+		Y:      headerHeight + 1,
+		Button: tea.MouseLeft,
+	})
+
+	if m.activeTab != 0 {
+		t.Errorf("expected activeTab=0 after click, got %d", m.activeTab)
+	}
+}
+
 func TestContextKeyMap_NoDiffReviewOnFileTab(t *testing.T) {
 	m := newTestModel(t)
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -12,6 +12,22 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+// tabLabel returns the display label for a tab (with leading/trailing space).
+func tabLabel(t *tab) string {
+	name := "[empty]"
+	if t.filePath != "" {
+		name = filepath.Base(t.filePath)
+	}
+	if t.kind == diffTab {
+		if t.diff != nil {
+			name = "[review] " + name
+		} else {
+			name = "[diff] " + name
+		}
+	}
+	return " " + name + " "
+}
+
 // cursorPosition represents screen-space cursor coordinates.
 // A zero value means no cursor is visible.
 type cursorPosition struct {
@@ -248,19 +264,7 @@ func (m *Model) renderTabBar(offset int) string {
 	var borders []string
 
 	for i, t := range m.tabs {
-		name := "[empty]"
-		if t.filePath != "" {
-			name = filepath.Base(t.filePath)
-		}
-		if t.kind == diffTab {
-			if t.diff != nil {
-				name = "[review] " + name
-			} else {
-				name = "[diff] " + name
-			}
-		}
-
-		label := " " + name + " "
+		label := tabLabel(t)
 		w := len([]rune(label))
 		if i == m.activeTab {
 			labels = append(labels, styleActive.Render(label))


### PR DESCRIPTION
## Overview

Add mouse click support on the tab bar to switch the active tab.

## Why

The tab bar (Y=1, Y=2) was not a mouse click target. `handleMouseClick` only processed clicks at `msg.Y >= contentStartY` (Y>=3), so clicking a tab had no effect. Users expect to click tabs to switch between them.

## What

- Extract `tabLabel(t *tab) string` helper from `renderTabBar` inline logic to share tab label computation between rendering and hit-testing
- Add `tabIndexAtX(x int) int` method that computes which tab index is at a given screen X coordinate using the same layout math as `renderTabBar`
- Add tab bar click detection in `handleMouseClick` for the tab bar rows (`headerHeight` to `headerHeight + tabBarHeight`)
- Add `tabSeparatorWidth` constant in `layout.go` to unify the separator width between `renderTabBar` and `tabIndexAtX`
- Add tests for `tabIndexAtX` (boundary values, no tabs, before/after tabs) and `TestMouseClick_TabBar` (click to switch active tab on both label and underline rows)

## Type of Change

- [x] Feature

## How to Test

```bash
go test ./internal/tui/... -run "TestTabIndexAtX|TestMouseClick_TabBar" -v
```

Manual: run `gra`, open multiple files, click on tab labels or underline area to switch between tabs.

## Checklist

- [x] Tests added
- [x] Self-reviewed
