### PR TITLE
refactor: move config directory from ~/.gracilius to ~/.config/gracilius

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ cmd/gra/
   main.go          Entry point, wiring, callback registration
 
 internal/
+  config/
+    config.go      DataDir() for data directory path
   tui/
     model.go       MCPServer interface, Model struct,
                    message types, NewModel
@@ -83,9 +85,12 @@ internal/
 ### Dependency Graph
 
 ```txt
+cmd/gra → internal/config   (DataDir)
 cmd/gra → internal/tui      (Model, message types)
 cmd/gra → internal/server   (Server creation, callbacks)
-       internal/server → internal/protocol
+       internal/server  → internal/config
+       internal/server  → internal/protocol
+       internal/comment → internal/config
 ```
 
 `tui` has zero dependencies on other internal packages.
@@ -160,7 +165,7 @@ WebSocket server based on `gorilla/websocket`.
 - Bind: `127.0.0.1:{port}` (default 18765)
 - Port retry: up to 10 attempts, incrementing port
 - Auth: `x-claude-code-ide-authorization` header
-- Auth token: persisted at `~/.gracilius/token` (UUID v4)
+- Auth token: persisted at `~/.config/gracilius/token` (UUID v4)
 - Keepalive: 30s ping / 60s timeout
 - Selection notification debounce: 100ms
 

--- a/cmd/gra/main.go
+++ b/cmd/gra/main.go
@@ -14,6 +14,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/708u/gracilius/internal/comment"
+	"github.com/708u/gracilius/internal/config"
 	"github.com/708u/gracilius/internal/server"
 	"github.com/708u/gracilius/internal/tui"
 	"github.com/alecthomas/kong"
@@ -48,11 +49,11 @@ func main() {
 
 func (c *ViewCmd) Run() error {
 	// Log file setup
-	homeDir, err := os.UserHomeDir()
+	dataDir, err := config.DataDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get data directory: %w", err)
 	}
-	logDir := filepath.Join(homeDir, ".gracilius", "logs")
+	logDir := filepath.Join(dataDir, "logs")
 	if err := os.MkdirAll(logDir, 0700); err != nil {
 		return fmt.Errorf("failed to create log directory: %w", err)
 	}

--- a/internal/comment/repository.go
+++ b/internal/comment/repository.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/708u/gracilius/internal/config"
 )
 
 // Entry represents a review comment attached to a file.
@@ -95,18 +97,18 @@ type Repository struct {
 }
 
 // NewRepository creates a new Repository for the given rootDir.
-// The store directory is ~/.gracilius/projects/{basename-hash8}/
+// The store directory is ~/.config/gracilius/projects/{basename-hash8}/
 func NewRepository(rootDir string) (*Repository, error) {
-	homeDir, err := os.UserHomeDir()
+	dataDir, err := config.DataDir()
 	if err != nil {
-		return nil, fmt.Errorf("get home directory: %w", err)
+		return nil, fmt.Errorf("get data directory: %w", err)
 	}
 
 	base := filepath.Base(rootDir)
 	hash := sha256.Sum256([]byte(rootDir))
 	name := fmt.Sprintf("%s-%x", base, hash[:4])
 
-	dir := filepath.Join(homeDir, ".gracilius", "projects", name)
+	dir := filepath.Join(dataDir, "projects", name)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("create project directory: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DataDir returns the path to the gracilius data directory.
+// Uses os.UserConfigDir ($XDG_CONFIG_HOME, falling back to ~/.config).
+func DataDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("get config directory: %w", err)
+	}
+	return filepath.Join(configDir, "gracilius"), nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/708u/gracilius/internal/config"
 	"github.com/708u/gracilius/internal/protocol"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -94,16 +95,15 @@ type selectionChange struct {
 	endChar   int
 }
 
-// loadOrCreateToken loads an existing token from ~/.gracilius/token or creates a new one.
+// loadOrCreateToken loads an existing token from ~/.config/gracilius/token or creates a new one.
 func loadOrCreateToken() string {
-	homeDir, err := os.UserHomeDir()
+	dataDir, err := config.DataDir()
 	if err != nil {
-		log.Printf("Failed to get home directory, using new token: %v", err)
+		log.Printf("Failed to get data directory, using new token: %v", err)
 		return uuid.New().String()
 	}
 
-	graciliusDir := filepath.Join(homeDir, ".gracilius")
-	tokenPath := filepath.Join(graciliusDir, "token")
+	tokenPath := filepath.Join(dataDir, "token")
 
 	// Try to read existing token
 	data, err := os.ReadFile(tokenPath)
@@ -119,8 +119,8 @@ func loadOrCreateToken() string {
 	token := uuid.New().String()
 
 	// Ensure directory exists
-	if err := os.MkdirAll(graciliusDir, 0700); err != nil {
-		log.Printf("Failed to create directory %s: %v", graciliusDir, err)
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		log.Printf("Failed to create directory %s: %v", dataDir, err)
 		return token
 	}
 


### PR DESCRIPTION
## Overview

Migrate gracilius data directory from `~/.gracilius/` to `~/.config/gracilius/` by introducing `internal/config` package.

## Why

The data directory path (`~/.gracilius/`) was hardcoded across 3 separate locations (`cmd/gra/main.go`, `internal/server/server.go`, `internal/comment/repository.go`). This violates DRY and uses a non-standard config location. Moving to `~/.config/gracilius/` aligns with XDG Base Directory Specification.

## What

- Add `internal/config` package with `DataDir()` function using `os.UserConfigDir()` (XDG-aware)
- Replace scattered `os.UserHomeDir()` + `".gracilius"` path construction in:
  - `cmd/gra/main.go` (log directory)
  - `internal/server/server.go` (auth token)
  - `internal/comment/repository.go` (comment store)
- Update `CLAUDE.md`: package layout, dependency graph, token path

**Breaking change**: no migration from `~/.gracilius/`. Existing token and comments data will not be carried over.

### Directory structure after migration

```txt
~/.config/gracilius/
├── token
├── logs/
│   ├── {uuidv7}.log
│   └── latest -> {uuidv7}.log
└── projects/
    └── {basename}-{hash8}/
        └── comments.json
```

## Type of Change

- [x] Refactoring

## How to Test

```bash
go build ./...
go test ./...
```

Verify data directory is created at `~/.config/gracilius/` on startup.

## Checklist

- [x] Self-reviewed
