### PR TITLE
feat: update diff view when file changes on disk

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -78,6 +78,7 @@ type IdeConnectedMsg struct{}
 
 // fileChangedMsg notifies the TUI that the watched file has changed.
 type fileChangedMsg struct {
+	path  string
 	lines []string
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -212,10 +212,13 @@ func (m *Model) closeTab(idx int) {
 	if t.kind == diffTab {
 		t.rejectAndClear()
 	}
-	if t.filePath != "" && t.kind == fileTab && m.watcher != nil {
-		_ = m.watcher.Remove(t.filePath)
-	}
+	filePath := t.filePath
 	m.tabs = slices.Delete(m.tabs, idx, idx+1)
+
+	if filePath != "" {
+		m.unwatchIfOrphaned(filePath)
+	}
+
 	if len(m.tabs) == 0 {
 		m.activeTab = 0
 		m.focusPane = paneTree
@@ -227,18 +230,39 @@ func (m *Model) closeTab(idx int) {
 // closeDiffTabs removes all diff tabs.
 func (m *Model) closeDiffTabs() {
 	tabs := make([]*tab, 0, len(m.tabs))
+	var removedPaths []string
 	for _, t := range m.tabs {
 		if t.kind == diffTab {
 			t.rejectAndClear()
+			if t.filePath != "" {
+				removedPaths = append(removedPaths, t.filePath)
+			}
 		} else {
 			tabs = append(tabs, t)
 		}
 	}
 	m.tabs = tabs
+	for _, p := range removedPaths {
+		m.unwatchIfOrphaned(p)
+	}
 	if len(m.tabs) == 0 {
 		m.activeTab = 0
 		m.focusPane = paneTree
 	} else if m.activeTab >= len(m.tabs) {
 		m.activeTab = len(m.tabs) - 1
 	}
+}
+
+// unwatchIfOrphaned removes the file from the watcher
+// if no remaining tab references it.
+func (m *Model) unwatchIfOrphaned(path string) {
+	if m.watcher == nil {
+		return
+	}
+	for _, t := range m.tabs {
+		if t.filePath == path {
+			return
+		}
+	}
+	_ = m.watcher.Remove(path)
 }

--- a/internal/tui/update_msg.go
+++ b/internal/tui/update_msg.go
@@ -11,7 +11,9 @@ import (
 
 // handleFileChanged processes file change notifications.
 func (m *Model) handleFileChanged(msg fileChangedMsg) (tea.Model, tea.Cmd) {
-	if t, ok := m.activeTabState(); ok {
+	// Update the active file tab if its path matches.
+	if t, ok := m.activeTabState(); ok &&
+		t.kind == fileTab && t.filePath == msg.path {
 		t.lines = msg.lines
 		t.syncContent(msg.lines)
 		t.highlightedLines = highlightFile(
@@ -27,6 +29,23 @@ func (m *Model) handleFileChanged(msg fileChangedMsg) (tea.Model, tea.Cmd) {
 			m.notifySelectionChanged()
 		}
 	}
+
+	// Update diff tabs whose old-side file matches.
+	oldSource := strings.Join(msg.lines, "\n")
+	for _, t := range m.tabs {
+		if t.kind != diffTab || t.filePath != msg.path {
+			continue
+		}
+		t.diffOldSource = oldSource
+		t.diffOldHighlights = highlightFile(t.filePath, oldSource, m.theme)
+		t.diffViewData = buildDiffData(msg.lines, t.lines)
+		if t.vp.Width() > diffSeparatorWidth {
+			off := t.vp.YOffset()
+			t.renderDiffContent(m.theme, t.vp.Width())
+			t.vp.SetYOffset(off)
+		}
+	}
+
 	cmd := m.watchFile()
 	return m, cmd
 }
@@ -117,6 +136,13 @@ func (m *Model) handleOpenDiff(msg OpenDiffMsg) (tea.Model, tea.Cmd) {
 	m.tabs = append(m.tabs, dt)
 	m.activeTab = len(m.tabs) - 1
 	m.focusPane = paneEditor
+
+	if m.watcher != nil {
+		if err := m.watcher.Add(msg.FilePath); err != nil {
+			log.Printf("Failed to watch diff file: %v", err)
+		}
+	}
+
 	return m, nil
 }
 

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -67,10 +67,54 @@ func TestHandleFileChanged(t *testing.T) {
 	tab.cursorChar = 5
 
 	// Simulate file change with fewer lines.
-	m.Update(fileChangedMsg{lines: []string{"only one line"}})
+	m.Update(fileChangedMsg{path: tab.filePath, lines: []string{"only one line"}})
 
 	if tab.cursorLine != 0 {
 		t.Errorf("expected cursorLine clipped to 0, got %d", tab.cursorLine)
+	}
+}
+
+func TestHandleFileChanged_UpdatesDiffTab(t *testing.T) {
+	m := newTestModel(t)
+
+	// Create a diff tab with known old/new content.
+	oldLines := []string{"old1", "old2"}
+	newLines := []string{"new1", "new2", "new3"}
+	dt := newDiffTab("/workspace/file.go", newLines, func(string) {}, func() {})
+	dt.diffViewData = buildDiffData(oldLines, newLines)
+	dt.diffOldSource = "old1\nold2"
+	m.tabs = append(m.tabs, dt)
+	m.activeTab = 0
+
+	// Simulate the on-disk file changing.
+	updatedOldLines := []string{"updated1", "updated2", "updated3"}
+	m.Update(fileChangedMsg{
+		path:  "/workspace/file.go",
+		lines: updatedOldLines,
+	})
+
+	if dt.diffOldSource != "updated1\nupdated2\nupdated3" {
+		t.Errorf("expected diffOldSource updated, got %q", dt.diffOldSource)
+	}
+	if dt.diffViewData == nil {
+		t.Fatal("expected diffViewData to be rebuilt")
+	}
+}
+
+func TestHandleFileChanged_IgnoresUnrelatedPath(t *testing.T) {
+	content := "line1\nline2\nline3"
+	m := newTestModelWithFile(t, content)
+	tab := m.tabs[0]
+
+	// Send a change for a different file.
+	m.Update(fileChangedMsg{
+		path:  "/some/other/file.go",
+		lines: []string{"changed"},
+	})
+
+	// The active tab should be untouched.
+	if len(tab.lines) != 3 {
+		t.Errorf("expected 3 lines unchanged, got %d", len(tab.lines))
 	}
 }
 

--- a/internal/tui/watch.go
+++ b/internal/tui/watch.go
@@ -29,7 +29,7 @@ func (m *Model) watchFile() tea.Cmd {
 						log.Printf("Error reading file: %v", err)
 						continue
 					}
-					return fileChangedMsg{lines: splitLines(content)}
+					return fileChangedMsg{path: event.Name, lines: splitLines(content)}
 				}
 			case err, ok := <-w.Errors:
 				if !ok {


### PR DESCRIPTION
## Overview

Diff view now updates in real-time when the underlying file
changes on disk, eliminating the need to close and reopen
the tab.

## Why

When reviewing diffs proposed by Claude Code, the on-disk file
may change (e.g. the user saves edits or another tool modifies
it). Previously the diff view did not reflect these changes,
forcing users to close and reopen the diff tab to see the
updated comparison. This broke the review flow.

Closes #66

## What

- Add `path` field to `fileChangedMsg` so file change events
  can be routed to the correct tab by path matching
- Register diff tab files with the fsnotify watcher on open
  (`handleOpenDiff`)
- Extend `handleFileChanged` to update diff tabs: rebuild
  `diffOldSource`, `diffOldHighlights`, `diffViewData`, and
  re-render the diff content while preserving scroll position
- Replace unconditional `watcher.Remove` with
  `unwatchIfOrphaned` to avoid removing watches when multiple
  tabs reference the same file
- Add `unwatchIfOrphaned` helper with internal nil-guard for
  safe watcher cleanup in `closeTab` and `closeDiffTabs`

## Related

- #66

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. `go test ./internal/tui/...` — all tests pass
2. `go build -o gra ./cmd/gra/` — builds successfully
3. Manual: open a diff tab, modify the underlying file in
   another editor, and verify the diff view updates
   automatically

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed