### PR TITLE
refactor: unify tab selection interface for MCP notifications

### DIFF
--- a/internal/tui/notify.go
+++ b/internal/tui/notify.go
@@ -8,15 +8,14 @@ func (m *Model) notifySelectionChanged() {
 	if !ok {
 		return
 	}
-	startLine, startChar, endLine, endChar := t.normalizedSelection()
-
+	sel := t.getSelectionInfo()
 	m.server.NotifySelectionChanged(
 		t.filePath,
-		t.selectedText(),
-		startLine,
-		startChar,
-		endLine,
-		endChar,
+		sel.text,
+		sel.startLine,
+		sel.startChar,
+		sel.endLine,
+		sel.endChar,
 	)
 }
 
@@ -26,13 +25,14 @@ func (m *Model) notifyClearSelection() {
 	if !ok {
 		return
 	}
+	line, char := t.getCursorPos()
 	m.server.NotifySelectionChanged(
 		t.filePath,
 		"",
-		t.cursorLine,
-		t.cursorChar,
-		t.cursorLine,
-		t.cursorChar,
+		line,
+		char,
+		line,
+		char,
 	)
 }
 

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -101,6 +101,38 @@ func newDiffTab(filePath string, lines []string, onAccept func(string), onReject
 	}
 }
 
+// selectionInfo holds the selection state for MCP notification.
+type selectionInfo struct {
+	text      string
+	startLine int
+	startChar int
+	endLine   int
+	endChar   int
+}
+
+// getSelectionInfo returns current selection state for MCP notification.
+func (t *tab) getSelectionInfo() selectionInfo {
+	if t.kind == diffTab {
+		return selectionInfo{}
+	}
+	startLine, startChar, endLine, endChar := t.normalizedSelection()
+	return selectionInfo{
+		text:      t.selectedTextRange(startLine, startChar, endLine, endChar),
+		startLine: startLine,
+		startChar: startChar,
+		endLine:   endLine,
+		endChar:   endChar,
+	}
+}
+
+// getCursorPos returns cursor position as (line, char).
+func (t *tab) getCursorPos() (int, int) {
+	if t.kind == diffTab {
+		return 0, 0
+	}
+	return t.cursorLine, t.cursorChar
+}
+
 // configureGutter sets up the LeftGutterFunc for line numbers
 // with comment markers.
 func (t *tab) configureGutter(digitWidth int) {
@@ -195,7 +227,11 @@ func commentDisplayRows(text string) int {
 // selectedText returns the text within the current selection range.
 func (t *tab) selectedText() string {
 	startLine, startChar, endLine, endChar := t.normalizedSelection()
+	return t.selectedTextRange(startLine, startChar, endLine, endChar)
+}
 
+// selectedTextRange returns the text within the given range.
+func (t *tab) selectedTextRange(startLine, startChar, endLine, endChar int) string {
 	if startLine == endLine {
 		if startLine < len(t.lines) {
 			runes := []rune(t.lines[startLine])


### PR DESCRIPTION
## Overview

Unify the tab selection interface so that `notify.go` does not directly depend on file-tab-specific fields.

## Why

`notifySelectionChanged()` / `notifyClearSelection()` in `notify.go` directly access file-tab-specific fields (`normalizedSelection()`, `selectedText()`, `cursorLine`, `cursorChar`). When diff tab gains cursor/selection support, every call site would need `if t.kind == diffTab` branches. This refactoring centralizes the tab-kind dispatch into two methods on `tab`, keeping callers clean.

## What

- Add `selectionInfo` type and `getSelectionInfo()` method to `tab` that returns selection state regardless of tab kind (file tab uses existing logic; diff tab returns zero value for now)
- Add `getCursorPos()` method to `tab` that returns cursor position regardless of tab kind
- Update `notifySelectionChanged()` and `notifyClearSelection()` in `notify.go` to use the new unified methods
- Extract `selectedTextRange()` from `selectedText()` to avoid double `normalizedSelection()` computation inside `getSelectionInfo()`

## Type of Change

- [x] Refactoring

## How to Test

```bash
go build -o gra ./cmd/gra/ && go test ./...
```

1. File tab: cursor movement sends `selection_changed` notification
2. File tab: text selection sends `selection_changed` notification
3. SwitchPane (Tab): sends clear selection notification
4. Claude Code connection: sends `selection_changed` notification
5. Diff tab: no errors when displayed

## Checklist

- [x] Self-reviewed