### PR TITLE
refactor: extract diff editor renderer from renderEditor

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -431,9 +431,36 @@ func (m *Model) renderTree(width, height int) []string {
 	return lines
 }
 
+// renderDiffEditor generates the editor pane lines for a diff tab.
+// The viewport owns scrolling; we slice cached rendered lines directly.
+func (m *Model) renderDiffEditor(t *tab, lo layout) []string {
+	width := lo.editorWidth
+	height := lo.contentHeight
+
+	t.ensureDiffContent(m.theme, width)
+	m.lastMapping = nil
+
+	off := t.vp.YOffset()
+	end := min(off+height, len(t.diffCachedLines))
+	diffLines := make([]string, 0, height)
+	if off < len(t.diffCachedLines) {
+		diffLines = append(diffLines, t.diffCachedLines[off:end]...)
+	}
+	for len(diffLines) < height {
+		diffLines = append(diffLines, padRight("", width))
+	}
+	return diffLines
+}
+
 // renderEditor generates the editor pane lines.
 func (m *Model) renderEditor(lo layout) []string {
 	t, hasTab := m.activeTabState()
+
+	// Diff view dispatch: separate renderer owns the diff path.
+	if hasTab && t.diffViewData != nil {
+		return m.renderDiffEditor(t, lo)
+	}
+
 	width := lo.editorWidth
 	height := lo.contentHeight
 	lnw := lo.lineNumWidth
@@ -441,22 +468,6 @@ func (m *Model) renderEditor(lo layout) []string {
 
 	lines := make([]string, 0, height)
 	var mapping []visualEntry
-
-	// Diff view dispatch: viewport owns scroll, we slice cached lines directly.
-	if hasTab && t.diffViewData != nil {
-		t.ensureDiffContent(m.theme, width)
-		m.lastMapping = nil
-		off := t.vp.YOffset()
-		end := min(off+height, len(t.diffCachedLines))
-		diffLines := make([]string, 0, height)
-		if off < len(t.diffCachedLines) {
-			diffLines = append(diffLines, t.diffCachedLines[off:end]...)
-		}
-		for len(diffLines) < height {
-			diffLines = append(diffLines, padRight("", width))
-		}
-		return diffLines
-	}
 
 	if !hasTab || len(t.lines) == 0 {
 		emptyMsg := emptyStateMsg


### PR DESCRIPTION
## Overview

Extract diff view rendering from `renderEditor` into a dedicated `renderDiffEditor` method.

## Why

`renderEditor()` handles both file tab and diff tab rendering in a single function. Separating the diff view path makes it easier to add diff-specific features (cursor, selection highlight) without increasing the complexity of the shared function.

## What

- Extract diff view rendering logic from `renderEditor` (view.go:446-458) into new `renderDiffEditor(t *tab, lo layout)` method
- Move diff dispatch guard above variable allocations to avoid unnecessary `make([]string, 0, height)` on the diff path
- No behavioral changes: rendering output is identical

## Type of Change

- [x] Refactoring

## How to Test

1. Open a diff tab and verify side-by-side diff displays correctly
2. Scroll (Up/Down/wheel) in diff view
3. Open a file tab and verify normal editor rendering is unaffected
4. `go build -o gra ./cmd/gra/ && go test ./...`

## Checklist

- [x] Self-reviewed