### PR TITLE
refactor: unify char/line selection into single line-granular select

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -14,8 +14,7 @@ type keyMap struct {
 	Down          key.Binding
 	Left          key.Binding
 	Right         key.Binding
-	CharSelect    key.Binding
-	LineSelect    key.Binding
+	Select        key.Binding
 	Copy          key.Binding
 	Comment       key.Binding
 	CommentSubmit key.Binding
@@ -69,13 +68,9 @@ func newKeyMap() keyMap {
 			key.WithKeys("right", "l"),
 			key.WithHelp("→/l", "right"),
 		),
-		CharSelect: key.NewBinding(
+		Select: key.NewBinding(
 			key.WithKeys("v"),
 			key.WithHelp("v", "select"),
-		),
-		LineSelect: key.NewBinding(
-			key.WithKeys("V"),
-			key.WithHelp("V", "select line"),
 		),
 		Copy: key.NewBinding(
 			key.WithKeys("y"),
@@ -152,7 +147,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.SwitchPane, k.SwitchPanel, k.ToggleSidebar,
 		k.PrevTab, k.NextTab, k.CloseTab,
-		k.CharSelect, k.LineSelect, k.Copy, k.OpenFile,
+		k.Select, k.Copy, k.OpenFile,
 		k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit,
 	}
 }
@@ -162,7 +157,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right, k.GoTop, k.GoBottom, k.BlockUp, k.BlockDown},
 		{k.Enter, k.SwitchPane, k.SwitchPanel, k.ToggleSidebar, k.PrevTab, k.NextTab, k.CloseTab},
-		{k.CharSelect, k.LineSelect, k.Copy, k.Comment, k.ClearAll, k.OpenFile, k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit},
+		{k.Select, k.Copy, k.Comment, k.ClearAll, k.OpenFile, k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit},
 	}
 }
 
@@ -172,8 +167,7 @@ func (m *Model) contextKeyMap() help.KeyMap {
 	km := m.keys
 	t, hasTab := m.activeTabState()
 	isDiffReview := hasTab && t.diff != nil
-	km.CharSelect.SetEnabled(hasTab && m.focusPane == paneEditor)
-	km.LineSelect.SetEnabled(hasTab && m.focusPane == paneEditor)
+	km.Select.SetEnabled(hasTab && m.focusPane == paneEditor)
 	km.Copy.SetEnabled(hasTab && m.focusPane == paneEditor && t.selecting)
 	km.Comment.SetEnabled(hasTab && m.focusPane == paneEditor)
 	km.ClearAll.SetEnabled(hasTab && m.focusPane == paneEditor)

--- a/internal/tui/tab.go
+++ b/internal/tui/tab.go
@@ -33,7 +33,6 @@ type tab struct {
 	anchorLine       int
 	anchorChar       int
 	selecting        bool
-	lineSelect       bool
 	vp               viewport.Model
 
 	comments     []comment.Entry
@@ -304,17 +303,16 @@ func (t *tab) selectedTextRange(startLine, startChar, endLine, endChar int) stri
 }
 
 // normalizedSelection returns the selection range with start <= end.
+// Selection is always line-granular: startChar is 0 and endChar is the
+// full length of the end line.
 func (t *tab) normalizedSelection() (startLine, startChar, endLine, endChar int) {
-	startLine, startChar = t.anchorLine, t.anchorChar
-	endLine, endChar = t.cursorLine, t.cursorChar
-	if startLine > endLine || (startLine == endLine && startChar > endChar) {
+	startLine = t.anchorLine
+	endLine = t.cursorLine
+	if startLine > endLine {
 		startLine, endLine = endLine, startLine
-		startChar, endChar = endChar, startChar
 	}
-	if t.lineSelect {
-		startChar = 0
-		endChar = t.lineLen(endLine)
-	}
+	startChar = 0
+	endChar = t.lineLen(endLine)
 	return
 }
 
@@ -360,7 +358,6 @@ func (t *tab) resetEditorState() {
 	t.anchorChar = 0
 	t.vp.SetYOffset(0)
 	t.selecting = false
-	t.lineSelect = false
 	t.comments = nil
 	t.inputMode = false
 	t.commentInput.Reset()

--- a/internal/tui/update_key.go
+++ b/internal/tui/update_key.go
@@ -213,8 +213,7 @@ func (m *Model) handleDiffKeyNormal(t *tab, msg tea.KeyPressMsg) (tea.Model, tea
 	// No-op: suppress file-tab actions that should not fire on diff tabs.
 	case key.Matches(msg, m.keys.Left),
 		key.Matches(msg, m.keys.Right),
-		key.Matches(msg, m.keys.CharSelect),
-		key.Matches(msg, m.keys.LineSelect),
+		key.Matches(msg, m.keys.Select),
 		key.Matches(msg, m.keys.Comment),
 		key.Matches(msg, m.keys.BlockUp),
 		key.Matches(msg, m.keys.BlockDown):
@@ -239,7 +238,6 @@ func (m *Model) handleKeyNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Cancel):
 		if hasTab && t.selecting {
 			t.selecting = false
-			t.lineSelect = false
 			m.notifyClearSelection()
 			return m, nil
 		}
@@ -350,32 +348,13 @@ func (m *Model) handleKeyNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.notifySelectionChanged()
 			}
 		}
-	case key.Matches(msg, m.keys.CharSelect):
+	case key.Matches(msg, m.keys.Select):
 		if hasTab && m.focusPane == paneEditor && len(t.lines) > 0 {
-			switch {
-			case t.selecting && !t.lineSelect:
+			if t.selecting {
 				t.selecting = false
 				m.notifyClearSelection()
-			case t.selecting && t.lineSelect:
-				t.lineSelect = false
-				m.notifySelectionChanged()
-			default:
+			} else {
 				t.startSelecting()
-			}
-		}
-	case key.Matches(msg, m.keys.LineSelect):
-		if hasTab && m.focusPane == paneEditor && len(t.lines) > 0 {
-			switch {
-			case t.selecting && t.lineSelect:
-				t.selecting = false
-				t.lineSelect = false
-				m.notifyClearSelection()
-			case t.selecting && !t.lineSelect:
-				t.lineSelect = true
-				m.notifySelectionChanged()
-			default:
-				t.startSelecting()
-				t.lineSelect = true
 				m.notifySelectionChanged()
 			}
 		}
@@ -387,7 +366,6 @@ func (m *Model) handleKeyNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				t.inputStart = s
 				t.inputEnd = e
 				t.selecting = false
-				t.lineSelect = false
 			} else {
 				t.inputStart = t.cursorLine
 				t.inputEnd = t.cursorLine

--- a/internal/tui/update_mouse.go
+++ b/internal/tui/update_mouse.go
@@ -93,7 +93,6 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 		t.anchorLine = targetLine
 		t.anchorChar = targetChar
 		t.selecting = false
-		t.lineSelect = false
 		m.mouseDown = true
 		m.lastMouseLine = targetLine
 		m.lastMouseChar = targetChar


### PR DESCRIPTION
## Overview

Unify `CharSelect` (v) and `LineSelect` (V) into a single `Select` (v) key that always operates at line granularity.

## Why

gracilius is a code review tool where all selection consumers (comments, copy, MCP notifications) operate on full lines. The char-level selection mode added unnecessary complexity without practical benefit. Merging both modes into one simplifies the codebase and the user experience.

## What

- Rename `CharSelect` → `Select` in `keyMap`, remove `LineSelect` field and binding
- Remove `lineSelect bool` field from `tab` struct
- Simplify `normalizedSelection()` to always expand to full lines (`startChar=0`, `endChar=lineLen`)
- Simplify select key handler from a multi-branch state machine to a straightforward toggle
- Remove all `lineSelect` references from key, mouse, and reset handlers

## Type of Change

- [x] Refactoring

## How to Test

1. `go build -o gra ./cmd/gra/ && go test ./...`
2. Press `v` to start line selection, move cursor, press `v` again to cancel
3. Verify `V` has no effect
4. Mouse drag produces line-granular selection
5. `y` copies full lines
6. `i` opens comment input with correct line range
7. `selection_changed` MCP notification has `startChar=0` and `endChar=line length`

## Checklist

- [x] Tests pass
- [x] Lint clean
- [x] Self-reviewed