### PR TITLE
style: brighten dark theme diff background colors

### DIFF
--- a/internal/tui/diffrender.go
+++ b/internal/tui/diffrender.go
@@ -28,11 +28,11 @@ func diffColorsFor(theme themeConfig) diffColors {
 	}
 	if theme.name == "github-dark" {
 		return diffColors{
-			addBg:     bg("#0d2818"),
-			delBg:     bg("#2c1519"),
-			wordAddBg: bg("#174928"),
-			wordDelBg: bg("#6e302b"),
-			fillerBg:  bg("#1e1e1e"),
+			addBg:     bg("#122d1e"),
+			delBg:     bg("#351c20"),
+			wordAddBg: bg("#1f5c34"),
+			wordDelBg: bg("#7e3834"),
+			fillerBg:  bg("#222222"),
 		}
 	}
 	return diffColors{


### PR DESCRIPTION
## Overview

Brighten the dark theme (`github-dark`) diff background colors to improve text readability.

## Why

The existing dark theme diff colors were too dark, making it difficult to read code in added/deleted/modified lines. The low contrast between text and background reduced usability in dark terminal environments.

## What

Adjusted all 5 hex background colors in `diffColorsFor()` for the `github-dark` theme:

| Field | Before | After |
|-------|--------|-------|
| `addBg` | `#0d2818` | `#122d1e` |
| `delBg` | `#2c1519` | `#351c20` |
| `wordAddBg` | `#174928` | `#1f5c34` |
| `wordDelBg` | `#6e302b` | `#7e3834` |
| `fillerBg` | `#1e1e1e` | `#222222` |

Colors are brightened while preserving the original hue, maintaining visual distinction between add/delete/filler regions.

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [x] Other

## How to Test

1. `go build -o gra ./cmd/gra/`
2. Open a diff view in a dark terminal
3. Verify added/deleted/modified line backgrounds are brighter and more readable

## Checklist

- [x] Self-reviewed
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes