### PR TITLE
feat: add getCurrentSelection and getLatestSelection MCP tools

### DIFF
--- a/internal/protocol/handler.go
+++ b/internal/protocol/handler.go
@@ -96,6 +96,20 @@ type CloseTabCallback func()
 // IdeConnectedCallback is called when ide_connected is received.
 type IdeConnectedCallback func()
 
+// GetSelectionCallback returns the current selection state.
+// Returns nil when no selection is available.
+type GetSelectionCallback func() *SelectionResult
+
+// SelectionResult represents the result of getCurrentSelection / getLatestSelection.
+type SelectionResult struct {
+	Success   bool       `json:"success"`
+	Text      string     `json:"text,omitempty"`
+	FilePath  string     `json:"filePath,omitempty"`
+	FileURL   string     `json:"fileUrl,omitempty"`
+	Selection *Selection `json:"selection,omitempty"`
+	Message   string     `json:"message,omitempty"`
+}
+
 // MCPContent represents a content item in MCP response.
 type MCPContent struct {
 	Type string `json:"type"`
@@ -170,6 +184,7 @@ type Handler struct {
 	onOpenDiff       OpenDiffCallback
 	onCloseTab       CloseTabCallback
 	onIdeConnected   IdeConnectedCallback
+	onGetSelection   GetSelectionCallback
 
 	pendingDiffs map[string]*DiffResponder
 	diffMu       sync.Mutex
@@ -196,6 +211,11 @@ func (h *Handler) SetCloseTabCallback(cb CloseTabCallback) {
 // SetIdeConnectedCallback sets the callback for ide_connected events.
 func (h *Handler) SetIdeConnectedCallback(cb IdeConnectedCallback) {
 	h.onIdeConnected = cb
+}
+
+// SetGetSelectionCallback sets the callback for getCurrentSelection/getLatestSelection.
+func (h *Handler) SetGetSelectionCallback(cb GetSelectionCallback) {
+	h.onGetSelection = cb
 }
 
 // RejectAllPendingDiffs rejects all pending diff responses.
@@ -292,13 +312,41 @@ func (h *Handler) handleToolsList(req *Request) *Response {
 				Properties: map[string]propertySchema{},
 			},
 		},
+		{
+			Name:        "getCurrentSelection",
+			Description: "Get the current selection in the active editor",
+			InputSchema: inputSchema{
+				Type:       "object",
+				Properties: map[string]propertySchema{},
+			},
+		},
+		{
+			Name:        "getLatestSelection",
+			Description: "Get the latest selection from any editor",
+			InputSchema: inputSchema{
+				Type:       "object",
+				Properties: map[string]propertySchema{},
+			},
+		},
 	}
 	return NewResponse(req.ID, map[string]any{"tools": tools})
 }
 
-// fileURI converts an absolute file path to a file:// URI using net/url.
-func fileURI(path string) string {
+// FileURI converts an absolute file path to a file:// URI using net/url.
+func FileURI(path string) string {
 	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+func (h *Handler) handleGetSelection(fallbackMsg string) MCPResult {
+	var result *SelectionResult
+	if h.onGetSelection != nil {
+		result = h.onGetSelection()
+	}
+	if result == nil {
+		result = &SelectionResult{Message: fallbackMsg}
+	}
+	resultJSON, _ := json.Marshal(result)
+	return NewMCPResult(string(resultJSON))
 }
 
 func (h *Handler) handleToolsCall(req *Request, send func(*Response)) {
@@ -317,7 +365,7 @@ func (h *Handler) handleToolsCall(req *Request, send func(*Response)) {
 				rootPath = path
 			}
 			folders[i] = WorkspaceFolder{
-				URI:  fileURI(path),
+				URI:  FileURI(path),
 				Name: path,
 				Path: path,
 			}
@@ -363,6 +411,10 @@ func (h *Handler) handleToolsCall(req *Request, send func(*Response)) {
 		}
 	case "getDiagnostics":
 		send(NewResponse(req.ID, NewMCPResultEmpty()))
+	case "getCurrentSelection":
+		send(NewResponse(req.ID, h.handleGetSelection("No active editor found")))
+	case "getLatestSelection":
+		send(NewResponse(req.ID, h.handleGetSelection("No selection available")))
 	case "closeAllDiffTabs":
 		h.RejectAllPendingDiffs()
 		if h.onCloseTab != nil {

--- a/internal/protocol/handler_test.go
+++ b/internal/protocol/handler_test.go
@@ -365,6 +365,173 @@ func TestCloseAllDiffTabs_RejectsPending(t *testing.T) {
 	}
 }
 
+func TestToolsList_IncludesSelectionTools(t *testing.T) {
+	h := NewHandler([]string{"/workspace"})
+	req := &Request{
+		JSONRPC: "2.0",
+		ID:      testID(),
+		Method:  "tools/list",
+	}
+
+	send, ch := collectSend()
+	h.HandleMessage(req, send)
+
+	resp := <-ch
+	data, _ := json.Marshal(resp.Result)
+	var result struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("failed to unmarshal tools/list result: %v", err)
+	}
+
+	want := map[string]bool{
+		"getCurrentSelection": false,
+		"getLatestSelection":  false,
+	}
+	for _, tool := range result.Tools {
+		if _, ok := want[tool.Name]; ok {
+			want[tool.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("tools/list should include %s", name)
+		}
+	}
+}
+
+func TestGetCurrentSelection_NoCallback(t *testing.T) {
+	h := NewHandler([]string{"/workspace"})
+
+	params, _ := json.Marshal(ToolCallParams{Name: "getCurrentSelection"})
+	req := &Request{
+		JSONRPC: "2.0",
+		ID:      testID(),
+		Method:  "tools/call",
+		Params:  params,
+	}
+
+	send, ch := collectSend()
+	h.HandleMessage(req, send)
+
+	resp := <-ch
+	data, _ := json.Marshal(resp.Result)
+	var mcpResult MCPResult
+	if err := json.Unmarshal(data, &mcpResult); err != nil {
+		t.Fatalf("failed to unmarshal MCP result: %v", err)
+	}
+	if len(mcpResult.Content) == 0 {
+		t.Fatal("expected content in response")
+	}
+
+	var selResult SelectionResult
+	if err := json.Unmarshal([]byte(mcpResult.Content[0].Text), &selResult); err != nil {
+		t.Fatalf("failed to unmarshal selection result: %v", err)
+	}
+	if selResult.Success {
+		t.Fatal("expected success=false when no callback is set")
+	}
+	if selResult.Message != "No active editor found" {
+		t.Fatalf("expected fallback message, got %q", selResult.Message)
+	}
+}
+
+func TestGetCurrentSelection_WithSelection(t *testing.T) {
+	h := NewHandler([]string{"/workspace"})
+
+	expected := &SelectionResult{
+		Success:  true,
+		Text:     "selected text",
+		FilePath: "/workspace/main.go",
+		FileURL:  "file:///workspace/main.go",
+		Selection: &Selection{
+			Start: Position{Line: 10, Character: 5},
+			End:   Position{Line: 10, Character: 18},
+		},
+	}
+	h.SetGetSelectionCallback(func() *SelectionResult {
+		return expected
+	})
+
+	params, _ := json.Marshal(ToolCallParams{Name: "getCurrentSelection"})
+	req := &Request{
+		JSONRPC: "2.0",
+		ID:      testID(),
+		Method:  "tools/call",
+		Params:  params,
+	}
+
+	send, ch := collectSend()
+	h.HandleMessage(req, send)
+
+	resp := <-ch
+	data, _ := json.Marshal(resp.Result)
+	var mcpResult MCPResult
+	if err := json.Unmarshal(data, &mcpResult); err != nil {
+		t.Fatalf("failed to unmarshal MCP result: %v", err)
+	}
+
+	var selResult SelectionResult
+	if err := json.Unmarshal([]byte(mcpResult.Content[0].Text), &selResult); err != nil {
+		t.Fatalf("failed to unmarshal selection result: %v", err)
+	}
+	if !selResult.Success {
+		t.Fatal("expected success=true")
+	}
+	if selResult.Text != "selected text" {
+		t.Fatalf("expected 'selected text', got %q", selResult.Text)
+	}
+	if selResult.FilePath != "/workspace/main.go" {
+		t.Fatalf("expected '/workspace/main.go', got %q", selResult.FilePath)
+	}
+	if selResult.Selection.Start.Line != 10 || selResult.Selection.Start.Character != 5 {
+		t.Fatalf("unexpected start position: %+v", selResult.Selection.Start)
+	}
+	if selResult.Selection.End.Line != 10 || selResult.Selection.End.Character != 18 {
+		t.Fatalf("unexpected end position: %+v", selResult.Selection.End)
+	}
+}
+
+func TestGetLatestSelection_NoSelection(t *testing.T) {
+	h := NewHandler([]string{"/workspace"})
+
+	h.SetGetSelectionCallback(func() *SelectionResult {
+		return nil
+	})
+
+	params, _ := json.Marshal(ToolCallParams{Name: "getLatestSelection"})
+	req := &Request{
+		JSONRPC: "2.0",
+		ID:      testID(),
+		Method:  "tools/call",
+		Params:  params,
+	}
+
+	send, ch := collectSend()
+	h.HandleMessage(req, send)
+
+	resp := <-ch
+	data, _ := json.Marshal(resp.Result)
+	var mcpResult MCPResult
+	if err := json.Unmarshal(data, &mcpResult); err != nil {
+		t.Fatalf("failed to unmarshal MCP result: %v", err)
+	}
+
+	var selResult SelectionResult
+	if err := json.Unmarshal([]byte(mcpResult.Content[0].Text), &selResult); err != nil {
+		t.Fatalf("failed to unmarshal selection result: %v", err)
+	}
+	if selResult.Success {
+		t.Fatal("expected success=false when callback returns nil")
+	}
+	if selResult.Message != "No selection available" {
+		t.Fatalf("expected fallback message, got %q", selResult.Message)
+	}
+}
+
 func TestDiffResponder_ConcurrentSafety(t *testing.T) {
 	send, ch := collectSend()
 	r := &DiffResponder{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,7 +9,6 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -95,6 +94,14 @@ type selectionChange struct {
 	endChar   int
 }
 
+func (sc *selectionChange) toSelection() protocol.Selection {
+	return protocol.Selection{
+		Start:   protocol.Position{Line: sc.startLine, Character: sc.startChar},
+		End:     protocol.Position{Line: sc.endLine, Character: sc.endChar},
+		IsEmpty: sc.startLine == sc.endLine && sc.startChar == sc.endChar,
+	}
+}
+
 // loadOrCreateToken loads an existing token from ~/.config/gracilius/token or creates a new one.
 func loadOrCreateToken() string {
 	dataDir, err := config.DataDir()
@@ -138,16 +145,19 @@ func loadOrCreateToken() string {
 func New(workspaceFolders []string) (*Server, error) {
 	authToken := loadOrCreateToken()
 
-	return &Server{
+	h := protocol.NewHandler(workspaceFolders)
+	s := &Server{
 		authToken:        authToken,
 		workspaceFolders: workspaceFolders,
-		handler:          protocol.NewHandler(workspaceFolders),
+		handler:          h,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				return true
 			},
 		},
-	}, nil
+	}
+	h.SetGetSelectionCallback(s.GetLatestSelection)
+	return s, nil
 }
 
 // Listen binds a random port and creates the lock file.
@@ -250,6 +260,25 @@ func (s *Server) SetIdeConnectedCallback(cb protocol.IdeConnectedCallback) {
 	s.handler.SetIdeConnectedCallback(cb)
 }
 
+// GetLatestSelection returns the last sent selection state.
+func (s *Server) GetLatestSelection() *protocol.SelectionResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lastSentSelection == nil {
+		return nil
+	}
+	sel := s.lastSentSelection
+	selection := sel.toSelection()
+	return &protocol.SelectionResult{
+		Success:   true,
+		Text:      sel.text,
+		FilePath:  sel.filePath,
+		FileURL:   protocol.FileURI(sel.filePath),
+		Selection: &selection,
+	}
+}
+
 // hasSelectionChanged checks if the selection has changed from the last sent state.
 func (s *Server) hasSelectionChanged(filePath, text string, startLine, startChar, endLine, endChar int) bool {
 	if s.lastSentSelection == nil {
@@ -320,28 +349,19 @@ func (s *Server) NotifySelectionChanged(filePath, text string, startLine, startC
 		n := s.pendingNotify
 		s.pendingNotify = nil
 		s.broadcastSelection(n)
-		s.lastSentSelection = n
 	})
 }
 
 // broadcastSelection sends a selection_changed notification to all connected clients.
 // The caller must hold s.mu.
 func (s *Server) broadcastSelection(sel *selectionChange) {
+	s.lastSentSelection = sel
+
 	params := protocol.SelectionChangedParams{
-		Text:     sel.text,
-		FilePath: sel.filePath,
-		FileURL:  (&url.URL{Scheme: "file", Path: sel.filePath}).String(),
-		Selection: protocol.Selection{
-			Start: protocol.Position{
-				Line:      sel.startLine,
-				Character: sel.startChar,
-			},
-			End: protocol.Position{
-				Line:      sel.endLine,
-				Character: sel.endChar,
-			},
-			IsEmpty: sel.startLine == sel.endLine && sel.startChar == sel.endChar,
-		},
+		Text:      sel.text,
+		FilePath:  sel.filePath,
+		FileURL:   protocol.FileURI(sel.filePath),
+		Selection: sel.toSelection(),
 	}
 
 	notification := protocol.NewNotification("selection_changed", params)


### PR DESCRIPTION
## Overview

Add `getCurrentSelection` and `getLatestSelection` MCP tools
to allow Claude Code CLI to re-query selection state on demand.

## Why

When Claude Code executes internal tools (e.g., Read),
the selection context disappears from system-reminder.
This happens because gracilius only sends `selection_changed`
once on change, unlike claudecode.nvim which continuously
re-sends on cursor events. By exposing selection query tools,
Claude Code CLI can re-fetch the selection when needed.

Also fixes a minor bug where `lastSentSelection` was not
updated on the comment notification (immediate send) path.

## What

- Add `getCurrentSelection` and `getLatestSelection` tools
  to `tools/list` and `tools/call` handler
- Add `SelectionResult` type and `GetSelectionCallback`
- Add `GetLatestSelection()` method to Server
- Move `lastSentSelection` update into `broadcastSelection()`
  to fix comment notification path
- Export `FileURI` helper for cross-package reuse
- Extract `selectionChange.toSelection()` to eliminate
  duplicated conversion logic
- Add tests for new tools (4 test cases)

## Type of Change

- [x] Feature
- [x] Bug fix

## How to Test

```bash
go test ./...
go build -o gra ./cmd/gra/
```

Manual verification:
1. Start gracilius and connect Claude Code
2. Select lines in gracilius
3. Have Claude Code execute a Read tool
4. Verify selection context is recoverable