### PR TITLE
feat: resend selection to Claude Code on terminal focus regain

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -279,6 +279,16 @@ func (s *Server) GetLatestSelection() *protocol.SelectionResult {
 	}
 }
 
+// ResendSelection re-broadcasts the last sent selection to all connected clients.
+// This bypasses debounce and change detection to force a re-send.
+func (s *Server) ResendSelection() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastSentSelection != nil {
+		s.broadcastSelection(s.lastSentSelection)
+	}
+}
+
 // hasSelectionChanged checks if the selection has changed from the last sent state.
 func (s *Server) hasSelectionChanged(filePath, text string, startLine, startChar, endLine, endChar int) bool {
 	if s.lastSentSelection == nil {

--- a/internal/tui/mock_test.go
+++ b/internal/tui/mock_test.go
@@ -32,6 +32,8 @@ func (s *mockServer) NotifySelectionChanged(
 	})
 }
 
+func (s *mockServer) ResendSelection() {}
+
 func (s *mockServer) lastNotification() (selectionNotification, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,6 +49,7 @@ type MCPServer interface {
 		filePath, text string,
 		startLine, startChar, endLine, endChar int,
 	)
+	ResendSelection()
 }
 
 // CommentRepository is the interface for comment persistence.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -94,7 +94,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.openFile.active {
 		switch msg.(type) {
 		case tea.KeyPressMsg, tea.MouseClickMsg,
-			tea.WindowSizeMsg,
+			tea.WindowSizeMsg, tea.FocusMsg,
 			fileChangedMsg, treeChangedMsg, commentsChangedMsg,
 			OpenDiffMsg, CloseDiffMsg,
 			quitTimeoutMsg, statusClearMsg, IdeConnectedMsg:
@@ -109,7 +109,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.search.active {
 		switch msg.(type) {
 		case tea.KeyPressMsg, tea.MouseClickMsg,
-			tea.WindowSizeMsg,
+			tea.WindowSizeMsg, tea.FocusMsg,
 			fileChangedMsg, treeChangedMsg, commentsChangedMsg,
 			OpenDiffMsg, CloseDiffMsg,
 			quitTimeoutMsg, statusClearMsg, IdeConnectedMsg:
@@ -122,6 +122,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case tea.FocusMsg:
+		m.server.ResendSelection()
+		return m, nil
 	case tea.KeyboardEnhancementsMsg:
 		m.enhancedKeyboard = msg.SupportsKeyDisambiguation()
 		return m, nil

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -72,6 +72,7 @@ func newView(content string) tea.View {
 	var v tea.View
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
+	v.ReportFocus = true
 	v.SetContent(content)
 	return v
 }


### PR DESCRIPTION
## Overview

Resend the last selection state to Claude Code when the TUI regains terminal focus.

## Why

When gracilius TUI loses focus and regains it, Claude Code may not know the current selection state. This causes a desync where Claude Code has no awareness of what the user is looking at after switching back to the terminal.

## What

- Enable terminal focus reporting via `ReportFocus = true` in `newView()`
- Add `Server.ResendSelection()` that bypasses debounce and change detection to force re-broadcast `lastSentSelection`
- Add `ResendSelection()` to the `MCPServer` interface
- Handle `tea.FocusMsg` in `Update()` to call `ResendSelection()` on focus regain
- Add `tea.FocusMsg` to overlay/search pass-through lists so resend works regardless of UI state

## Type of Change

- [x] Feature

## How to Test

1. `go build -o gra ./cmd/gra/` and start gracilius
2. Start Claude Code in another terminal with `CLAUDE_CODE_SSE_PORT=<port> claude`
3. Select text in gracilius (verify selection_changed is sent in logs)
4. Switch to another window (blur the terminal)
5. Switch back to gracilius (focus the terminal)
6. Verify in logs that selection_changed is re-sent on focus regain

## Checklist

- [x] Self-reviewed
