### PR TITLE
refactor: extract parseChangedFiles and add branch diff support

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -78,7 +78,7 @@ func (s *StatusReader) ChangedFiles() ([]ChangedFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("git diff: %w", err)
 	}
-	return s.parseChangedFiles(out, s.unstaged)
+	return parseChangedFiles(s.dir, out, s.unstaged)
 }
 
 // StagedFiles returns staged (cached) changed files.
@@ -87,7 +87,7 @@ func (s *StatusReader) StagedFiles() ([]ChangedFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("git diff --cached: %w", err)
 	}
-	return s.parseChangedFiles(out, s.staged)
+	return parseChangedFiles(s.dir, out, s.staged)
 }
 
 // UntrackedFiles returns untracked files.
@@ -125,9 +125,53 @@ func (s *StatusReader) UntrackedFiles() ([]ChangedFile, error) {
 	return files, nil
 }
 
+// BranchDiff returns files changed between baseRef and HEAD.
+func BranchDiff(dir, baseRef string) ([]ChangedFile, error) {
+	if baseRef == "" {
+		return nil, fmt.Errorf("baseRef must not be empty")
+	}
+	out, err := gitCmd(dir, "diff", baseRef+"..HEAD", "--name-status")
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s..HEAD: %w", baseRef, err)
+	}
+	readers := diffReader{
+		readOld: func(d, path string) ([]string, bool, error) {
+			return readCommitBlob(d, baseRef, path)
+		},
+		readNew: readHEADBlob,
+	}
+	return parseChangedFiles(dir, out, readers)
+}
+
+// MergeBase returns the merge-base commit between HEAD and ref.
+func MergeBase(dir, ref string) (string, error) {
+	out, err := gitCmd(dir, "merge-base", "HEAD", ref)
+	if err != nil {
+		return "", fmt.Errorf("git merge-base HEAD %s: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// DefaultBranch detects the default branch name for the repository.
+// It first tries symbolic-ref, then falls back to checking main and master.
+func DefaultBranch(dir string) (string, error) {
+	out, err := gitCmd(dir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		ref := strings.TrimSpace(string(out))
+		return strings.TrimPrefix(ref, "refs/remotes/origin/"), nil
+	}
+	for _, name := range []string{"main", "master"} {
+		if _, err := gitCmd(dir, "rev-parse", "--verify", name); err == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("cannot detect default branch")
+}
+
 // parseChangedFiles parses git diff --name-status output
 // using the provided diffReader for old and new content.
-func (s *StatusReader) parseChangedFiles(
+func parseChangedFiles(
+	dir string,
 	nameStatusOutput []byte,
 	readers diffReader,
 ) ([]ChangedFile, error) {
@@ -150,7 +194,7 @@ func (s *StatusReader) parseChangedFiles(
 		case status == StatusAdded:
 			cf.Status = StatusAdded
 			cf.Path = fields[1]
-			content, bin, readErr := readers.readNew(s.dir, cf.Path)
+			content, bin, readErr := readers.readNew(dir, cf.Path)
 			if readErr != nil {
 				return nil, readErr
 			}
@@ -162,11 +206,11 @@ func (s *StatusReader) parseChangedFiles(
 		case status == StatusModified:
 			cf.Status = StatusModified
 			cf.Path = fields[1]
-			old, oldBin, oldErr := readers.readOld(s.dir, cf.Path)
+			old, oldBin, oldErr := readers.readOld(dir, cf.Path)
 			if oldErr != nil {
 				return nil, oldErr
 			}
-			new_, newBin, newErr := readers.readNew(s.dir, cf.Path)
+			new_, newBin, newErr := readers.readNew(dir, cf.Path)
 			if newErr != nil {
 				return nil, newErr
 			}
@@ -179,7 +223,7 @@ func (s *StatusReader) parseChangedFiles(
 		case status == StatusDeleted:
 			cf.Status = StatusDeleted
 			cf.Path = fields[1]
-			old, bin, oldErr := readers.readOld(s.dir, cf.Path)
+			old, bin, oldErr := readers.readOld(dir, cf.Path)
 			if oldErr != nil {
 				return nil, oldErr
 			}
@@ -196,11 +240,11 @@ func (s *StatusReader) parseChangedFiles(
 			oldPath := fields[1]
 			newPath := fields[2]
 			cf.Path = newPath
-			old, oldBin, oldErr := readers.readOld(s.dir, oldPath)
+			old, oldBin, oldErr := readers.readOld(dir, oldPath)
 			if oldErr != nil {
 				return nil, oldErr
 			}
-			new_, newBin, newErr := readers.readNew(s.dir, newPath)
+			new_, newBin, newErr := readers.readNew(dir, newPath)
 			if newErr != nil {
 				return nil, newErr
 			}
@@ -232,6 +276,19 @@ func readWorkFile(root, relPath string) ([]string, bool, error) {
 	return splitLines(data), false, nil
 }
 
+// readCommitBlob reads a file from a specific commit ref.
+func readCommitBlob(dir, ref, path string) ([]string, bool, error) {
+	data, err := gitCmd(dir, "show", ref+":"+path)
+	if err != nil {
+		return nil, false, fmt.Errorf("git show %s:%s: %w", ref, path, err)
+	}
+	if isBinaryContent(data) {
+		return nil, true, nil
+	}
+	return splitLines(data), false, nil
+}
+
+// readGitBlob reads a file from the index (staging area).
 func readGitBlob(dir, path string) ([]string, bool, error) {
 	data, err := gitCmd(dir, "show", ":"+path)
 	if err != nil {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -435,5 +436,121 @@ func TestUntrackedFiles_RespectsGitignore(t *testing.T) {
 	}
 	if files[0].Path != "readme.txt" {
 		t.Fatalf("expected readme.txt, got %s", files[0].Path)
+	}
+}
+
+func TestBranchDiff(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "hello.txt", "hello\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "init")
+	run(t, dir, "git", "branch", "-m", "main")
+
+	// Create a feature branch with changes.
+	run(t, dir, "git", "checkout", "-b", "feature")
+	writeFile(t, dir, "hello.txt", "hello world\n")
+	writeFile(t, dir, "new.txt", "new file\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "feature changes")
+
+	base, err := MergeBase(dir, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := BranchDiff(dir, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+
+	// Files are sorted by git diff output order.
+	var modified, added ChangedFile
+	for _, f := range files {
+		switch f.Path {
+		case "hello.txt":
+			modified = f
+		case "new.txt":
+			added = f
+		}
+	}
+
+	if modified.Status != StatusModified {
+		t.Fatalf("expected status M for hello.txt, got %s", modified.Status)
+	}
+	if len(modified.OldContent) != 1 || modified.OldContent[0] != "hello" {
+		t.Fatalf("unexpected old content: %v", modified.OldContent)
+	}
+	if len(modified.NewContent) != 1 || modified.NewContent[0] != "hello world" {
+		t.Fatalf("unexpected new content: %v", modified.NewContent)
+	}
+
+	if added.Status != StatusAdded {
+		t.Fatalf("expected status A for new.txt, got %s", added.Status)
+	}
+	if len(added.NewContent) != 1 || added.NewContent[0] != "new file" {
+		t.Fatalf("unexpected new content: %v", added.NewContent)
+	}
+}
+
+func TestBranchDiff_MissingBaseRef(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "hello.txt", "hello\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "init")
+
+	_, err := BranchDiff(dir, "")
+	if err == nil {
+		t.Fatal("expected error for empty baseRef")
+	}
+}
+
+func TestDefaultBranch(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "hello.txt", "hello\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "init")
+
+	// Default branch created by git init is typically "main".
+	// Rename to "trunk" and create "master" to test fallback.
+	run(t, dir, "git", "branch", "-m", "trunk")
+	run(t, dir, "git", "checkout", "-b", "master")
+
+	branch, err := DefaultBranch(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if branch != "master" {
+		t.Fatalf("expected master, got %s", branch)
+	}
+}
+
+func TestMergeBase(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, dir, "hello.txt", "hello\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "init")
+	run(t, dir, "git", "branch", "-m", "main")
+
+	// Record the base commit.
+	baseOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBase := strings.TrimSpace(string(baseOut))
+
+	run(t, dir, "git", "checkout", "-b", "feature")
+	writeFile(t, dir, "hello.txt", "changed\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "feature commit")
+
+	got, err := MergeBase(dir, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != expectedBase {
+		t.Fatalf("expected %s, got %s", expectedBase, got)
 	}
 }


### PR DESCRIPTION
## Overview

Extract `parseChangedFiles` from `StatusReader` method to package-level function and add branch diff utilities.

## Why

`StatusReader` currently handles both working tree state reading (staged/unstaged/untracked) and the `parseChangedFiles` logic. To support branch diff comparison (e.g., comparing a feature branch against its merge-base), `parseChangedFiles` needs to be callable without constructing a `StatusReader`. Extracting it as a package-level function separates these concerns cleanly.

## What

- Extract `parseChangedFiles` from `StatusReader` method to package-level function with `dir` as first argument
- Add `BranchDiff(dir, baseRef)` to compare changes between a base ref and HEAD
- Add `MergeBase(dir, ref)` to find the merge-base commit between HEAD and a ref
- Add `DefaultBranch(dir)` to detect the repository's default branch name
- Add `readCommitBlob(dir, ref, path)` to read file content from a specific commit
- Add doc comments to `readGitBlob`
- Add tests for `BranchDiff`, `MergeBase`, `DefaultBranch`

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test ./internal/git/ -v -count=1
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed