### PR TITLE
refactor: change build output directory to out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .claude/user_instructions
 .claude/settings.local.json
-gra
+out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The command name is `gra`.
 
 ```bash
 # Build
-go build -o gra ./cmd/gra/
+go build -o out/gra ./cmd/gra/
 
 # Run
 go run ./cmd/gra/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test vet lint fmt fix clean
 
 build:
-	go build -o gra ./cmd/gra/
+	go build -o out/gra ./cmd/gra/
 
 test:
 	go test ./...
@@ -19,4 +19,4 @@ fix:
 	go fix ./...
 
 clean:
-	rm -f gra
+	rm -rf out


### PR DESCRIPTION
## Overview

Build成果物の出力先を `out/` ディレクトリに変更する。

## Why

ビルド成果物 `gra` がプロジェクトルートに直接配置されていた。
`out/` ディレクトリに分離し、ソースコードとビルド成果物の
管理を明確にする。

## What

- `Makefile`: build target の出力先を `out/gra` に変更
- `Makefile`: clean target を `rm -rf out` に変更
- `.gitignore`: `gra` を `out/` に変更
- `CLAUDE.md`: ビルドコマンドのドキュメントを更新

## Type of Change

- [x] Refactoring

## How to Test

```bash
make build && ls out/gra   # バイナリが生成されること
make clean && ls out/      # ディレクトリが削除されエラーになること
```

## Checklist

- [x] Self-reviewed