### PR TITLE
refactor: extract internal/diff package with word-diff logic

### DIFF
--- a/internal/diff/worddiff.go
+++ b/internal/diff/worddiff.go
@@ -1,4 +1,4 @@
-package tui
+package diff
 
 import (
 	"strings"
@@ -6,22 +6,22 @@ import (
 	diffmatchpatch "github.com/sergi/go-diff/diffmatchpatch"
 )
 
-type diffOp int
+type Op int
 
 const (
-	diffOpEqual diffOp = iota
-	diffOpInsert
-	diffOpDelete
+	OpEqual Op = iota
+	OpInsert
+	OpDelete
 )
 
-type wordSpan struct {
-	text string
-	op   diffOp
+type WordSpan struct {
+	Text string
+	Op   Op
 }
 
-// tokenize splits a string into tokens at whitespace/non-whitespace boundaries.
+// Tokenize splits a string into tokens at whitespace/non-whitespace boundaries.
 // Concatenating all returned tokens reproduces the original string.
-func tokenize(s string) []string {
+func Tokenize(s string) []string {
 	if len(s) == 0 {
 		return nil
 	}
@@ -47,12 +47,12 @@ func isSpaceRune(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 }
 
-// computeWordDiff computes word-level diffs between oldLine and newLine.
+// ComputeWordDiff computes word-level diffs between oldLine and newLine.
 // It returns spans for both the old and new sides, where each span is
 // tagged with its diff operation (equal, insert, or delete).
-func computeWordDiff(oldLine, newLine string) (oldSpans []wordSpan, newSpans []wordSpan) {
-	oldTokens := tokenize(oldLine)
-	newTokens := tokenize(newLine)
+func ComputeWordDiff(oldLine, newLine string) (oldSpans []WordSpan, newSpans []WordSpan) {
+	oldTokens := Tokenize(oldLine)
+	newTokens := Tokenize(newLine)
 
 	dmp := diffmatchpatch.New()
 
@@ -73,12 +73,12 @@ func computeWordDiff(oldLine, newLine string) (oldSpans []wordSpan, newSpans []w
 		}
 		switch d.Type {
 		case diffmatchpatch.DiffEqual:
-			oldSpans = append(oldSpans, wordSpan{text: text, op: diffOpEqual})
-			newSpans = append(newSpans, wordSpan{text: text, op: diffOpEqual})
+			oldSpans = append(oldSpans, WordSpan{Text: text, Op: OpEqual})
+			newSpans = append(newSpans, WordSpan{Text: text, Op: OpEqual})
 		case diffmatchpatch.DiffDelete:
-			oldSpans = append(oldSpans, wordSpan{text: text, op: diffOpDelete})
+			oldSpans = append(oldSpans, WordSpan{Text: text, Op: OpDelete})
 		case diffmatchpatch.DiffInsert:
-			newSpans = append(newSpans, wordSpan{text: text, op: diffOpInsert})
+			newSpans = append(newSpans, WordSpan{Text: text, Op: OpInsert})
 		}
 	}
 	return oldSpans, newSpans

--- a/internal/diff/worddiff_test.go
+++ b/internal/diff/worddiff_test.go
@@ -1,4 +1,4 @@
-package tui
+package diff
 
 import (
 	"strings"
@@ -6,48 +6,48 @@ import (
 )
 
 func TestComputeWordDiff_Identical(t *testing.T) {
-	old, new := computeWordDiff("hello world", "hello world")
+	old, new := ComputeWordDiff("hello world", "hello world")
 	for i, s := range old {
-		if s.op != diffOpEqual {
-			t.Errorf("oldSpans[%d]: expected diffOpEqual, got %d", i, s.op)
+		if s.Op != OpEqual {
+			t.Errorf("oldSpans[%d]: expected OpEqual, got %d", i, s.Op)
 		}
 	}
 	for i, s := range new {
-		if s.op != diffOpEqual {
-			t.Errorf("newSpans[%d]: expected diffOpEqual, got %d", i, s.op)
+		if s.Op != OpEqual {
+			t.Errorf("newSpans[%d]: expected OpEqual, got %d", i, s.Op)
 		}
 	}
 }
 
 func TestComputeWordDiff_VariableRename(t *testing.T) {
-	oldSpans, newSpans := computeWordDiff("x := foo + bar", "x := baz + bar")
+	oldSpans, newSpans := ComputeWordDiff("x := foo + bar", "x := baz + bar")
 
-	if !containsSpan(oldSpans, "foo", diffOpDelete) {
+	if !containsSpan(oldSpans, "foo", OpDelete) {
 		t.Fatal("expected oldSpans to contain 'foo' as delete")
 	}
-	if !containsSpan(newSpans, "baz", diffOpInsert) {
+	if !containsSpan(newSpans, "baz", OpInsert) {
 		t.Fatal("expected newSpans to contain 'baz' as insert")
 	}
 }
 
 func TestComputeWordDiff_InsertedWord(t *testing.T) {
-	_, newSpans := computeWordDiff("return value", "return new value")
+	_, newSpans := ComputeWordDiff("return value", "return new value")
 
-	if !containsSpan(newSpans, "new", diffOpInsert) {
+	if !containsSpan(newSpans, "new", OpInsert) {
 		t.Fatal("expected newSpans to contain 'new' as insert")
 	}
 }
 
 func TestComputeWordDiff_DeletedWord(t *testing.T) {
-	oldSpans, _ := computeWordDiff("return old value", "return value")
+	oldSpans, _ := ComputeWordDiff("return old value", "return value")
 
-	if !containsSpan(oldSpans, "old", diffOpDelete) {
+	if !containsSpan(oldSpans, "old", OpDelete) {
 		t.Fatal("expected oldSpans to contain 'old' as delete")
 	}
 }
 
 func TestComputeWordDiff_WhitespaceChange(t *testing.T) {
-	oldSpans, newSpans := computeWordDiff("a  b", "a b")
+	oldSpans, newSpans := ComputeWordDiff("a  b", "a b")
 
 	oldJoined := joinSpans(oldSpans)
 	newJoined := joinSpans(newSpans)
@@ -60,12 +60,12 @@ func TestComputeWordDiff_WhitespaceChange(t *testing.T) {
 
 	hasChange := false
 	for _, s := range oldSpans {
-		if s.op == diffOpDelete {
+		if s.Op == OpDelete {
 			hasChange = true
 		}
 	}
 	for _, s := range newSpans {
-		if s.op == diffOpInsert {
+		if s.Op == OpInsert {
 			hasChange = true
 		}
 	}
@@ -75,7 +75,7 @@ func TestComputeWordDiff_WhitespaceChange(t *testing.T) {
 }
 
 func TestComputeWordDiff_EmptyOld(t *testing.T) {
-	oldSpans, newSpans := computeWordDiff("", "hello world")
+	oldSpans, newSpans := ComputeWordDiff("", "hello world")
 
 	if len(oldSpans) != 0 {
 		t.Fatalf("expected 0 oldSpans, got %d", len(oldSpans))
@@ -84,14 +84,14 @@ func TestComputeWordDiff_EmptyOld(t *testing.T) {
 		t.Fatal("expected non-empty newSpans")
 	}
 	for _, s := range newSpans {
-		if s.op != diffOpInsert {
-			t.Errorf("expected all newSpans to be insert, got %d", s.op)
+		if s.Op != OpInsert {
+			t.Errorf("expected all newSpans to be insert, got %d", s.Op)
 		}
 	}
 }
 
 func TestComputeWordDiff_EmptyNew(t *testing.T) {
-	oldSpans, newSpans := computeWordDiff("hello world", "")
+	oldSpans, newSpans := ComputeWordDiff("hello world", "")
 
 	if len(newSpans) != 0 {
 		t.Fatalf("expected 0 newSpans, got %d", len(newSpans))
@@ -100,14 +100,14 @@ func TestComputeWordDiff_EmptyNew(t *testing.T) {
 		t.Fatal("expected non-empty oldSpans")
 	}
 	for _, s := range oldSpans {
-		if s.op != diffOpDelete {
-			t.Errorf("expected all oldSpans to be delete, got %d", s.op)
+		if s.Op != OpDelete {
+			t.Errorf("expected all oldSpans to be delete, got %d", s.Op)
 		}
 	}
 }
 
 func TestComputeWordDiff_IndentChange(t *testing.T) {
-	oldSpans, newSpans := computeWordDiff("\tfoo", "\t\tfoo")
+	oldSpans, newSpans := ComputeWordDiff("\tfoo", "\t\tfoo")
 
 	oldJoined := joinSpans(oldSpans)
 	newJoined := joinSpans(newSpans)
@@ -134,14 +134,14 @@ func TestComputeWordDiff_RoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldSpans, newSpans := computeWordDiff(tt.oldLine, tt.newLine)
+			oldSpans, newSpans := ComputeWordDiff(tt.oldLine, tt.newLine)
 
-			oldReconstructed := joinSpansFiltered(oldSpans, diffOpInsert)
+			oldReconstructed := joinSpansFiltered(oldSpans, OpInsert)
 			if oldReconstructed != tt.oldLine {
 				t.Errorf("old round-trip: expected %q, got %q", tt.oldLine, oldReconstructed)
 			}
 
-			newReconstructed := joinSpansFiltered(newSpans, diffOpDelete)
+			newReconstructed := joinSpansFiltered(newSpans, OpDelete)
 			if newReconstructed != tt.newLine {
 				t.Errorf("new round-trip: expected %q, got %q", tt.newLine, newReconstructed)
 			}
@@ -150,60 +150,60 @@ func TestComputeWordDiff_RoundTrip(t *testing.T) {
 }
 
 func TestTokenize_Basic(t *testing.T) {
-	got := tokenize("hello world")
+	got := Tokenize("hello world")
 	want := []string{"hello", " ", "world"}
 	assertTokens(t, got, want)
 }
 
 func TestTokenize_MultipleSpaces(t *testing.T) {
-	got := tokenize("a  b")
+	got := Tokenize("a  b")
 	want := []string{"a", "  ", "b"}
 	assertTokens(t, got, want)
 }
 
 func TestTokenize_LeadingWhitespace(t *testing.T) {
-	got := tokenize("  hello")
+	got := Tokenize("  hello")
 	want := []string{"  ", "hello"}
 	assertTokens(t, got, want)
 }
 
 func TestTokenize_Empty(t *testing.T) {
-	got := tokenize("")
+	got := Tokenize("")
 	if len(got) != 0 {
 		t.Fatalf("expected empty slice, got %v", got)
 	}
 }
 
 func TestTokenize_TabsAndSpaces(t *testing.T) {
-	got := tokenize("\thello world")
+	got := Tokenize("\thello world")
 	want := []string{"\t", "hello", " ", "world"}
 	assertTokens(t, got, want)
 }
 
 // --- helpers ---
 
-func containsSpan(spans []wordSpan, text string, op diffOp) bool {
+func containsSpan(spans []WordSpan, text string, op Op) bool {
 	for _, s := range spans {
-		if strings.Contains(s.text, text) && s.op == op {
+		if strings.Contains(s.Text, text) && s.Op == op {
 			return true
 		}
 	}
 	return false
 }
 
-func joinSpans(spans []wordSpan) string {
+func joinSpans(spans []WordSpan) string {
 	var b strings.Builder
 	for _, s := range spans {
-		b.WriteString(s.text)
+		b.WriteString(s.Text)
 	}
 	return b.String()
 }
 
-func joinSpansFiltered(spans []wordSpan, excludeOp diffOp) string {
+func joinSpansFiltered(spans []WordSpan, excludeOp Op) string {
 	var b strings.Builder
 	for _, s := range spans {
-		if s.op != excludeOp {
-			b.WriteString(s.text)
+		if s.Op != excludeOp {
+			b.WriteString(s.Text)
 		}
 	}
 	return b.String()

--- a/internal/tui/diffmodel.go
+++ b/internal/tui/diffmodel.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 
+	"github.com/708u/gracilius/internal/diff"
 	diffmatchpatch "github.com/sergi/go-diff/diffmatchpatch"
 )
 
@@ -23,8 +24,8 @@ type diffRow struct {
 	oldText    string
 	newText    string
 	rowType    diffRowType
-	oldSpans   []wordSpan // word-level diff spans (modified rows only)
-	newSpans   []wordSpan
+	oldSpans   []diff.WordSpan // word-level diff spans (modified rows only)
+	newSpans   []diff.WordSpan
 }
 
 // diffHunk represents a contiguous range of changed rows with context.
@@ -164,7 +165,7 @@ func buildDiffData(oldLines, newLines []string) *diffData {
 			maxLine = rows[i].newLineNum
 		}
 		if rows[i].rowType == diffRowModified {
-			rows[i].oldSpans, rows[i].newSpans = computeWordDiff(rows[i].oldText, rows[i].newText)
+			rows[i].oldSpans, rows[i].newSpans = diff.ComputeWordDiff(rows[i].oldText, rows[i].newText)
 		}
 	}
 

--- a/internal/tui/diffrender.go
+++ b/internal/tui/diffrender.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/708u/gracilius/internal/diff"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
 )
@@ -192,7 +193,7 @@ func diffSideBg(rowType diffRowType, isOld bool, colors diffColors) (lineBg, wor
 func wrapDiffSide(
 	lineNum int,
 	text string,
-	spans []wordSpan,
+	spans []diff.WordSpan,
 	syntaxRuns []styledRun,
 	rowType diffRowType,
 	isOld bool,
@@ -365,16 +366,16 @@ func writeDiffFiller(sb *strings.Builder, lineNum int, rowType diffRowType, isOl
 // renderWordDiffText renders word-level diff spans with background highlights.
 func renderWordDiffText(
 	sb *strings.Builder,
-	spans []wordSpan,
+	spans []diff.WordSpan,
 	lineBg string,
 	wordBg string,
 	textWidth int,
 ) {
 	var raw strings.Builder
 	for _, s := range spans {
-		expanded := expandTabs(s.text)
+		expanded := expandTabs(s.Text)
 		bg := lineBg
-		if s.op == diffOpInsert || s.op == diffOpDelete {
+		if s.Op == diff.OpInsert || s.Op == diff.OpDelete {
 			bg = wordBg
 		}
 		if bg != "" {
@@ -456,7 +457,7 @@ func renderSyntaxWithBg(sb *strings.Builder, runs []styledRun, bg string, textWi
 // Falls back to renderWordDiffText when syntaxRuns is nil.
 func renderWordDiffWithSyntax(
 	sb *strings.Builder,
-	spans []wordSpan,
+	spans []diff.WordSpan,
 	syntaxRuns []styledRun,
 	lineBg, wordBg string,
 	textWidth int,
@@ -474,7 +475,7 @@ func renderWordDiffWithSyntax(
 // into a flat slice of styledRuns with fg+bg merged into the ANSI field.
 // The returned runs have tabs expanded.
 func wordDiffToStyledRuns(
-	spans []wordSpan,
+	spans []diff.WordSpan,
 	syntaxRuns []styledRun,
 	lineBg, wordBg string,
 ) []styledRun {
@@ -489,13 +490,13 @@ func wordDiffToStyledRuns(
 	var out []styledRun
 	syntaxPos := 0
 	for _, span := range spans {
-		expanded := expandTabs(span.text)
+		expanded := expandTabs(span.Text)
 		bg := lineBg
-		if span.op == diffOpInsert || span.op == diffOpDelete {
+		if span.Op == diff.OpInsert || span.Op == diff.OpDelete {
 			bg = wordBg
 		}
 
-		spanRunes := []rune(span.text)
+		spanRunes := []rune(span.Text)
 		expandedRunes := []rune(expanded)
 
 		ei := 0


### PR DESCRIPTION
## Summary

Step 1 of 2 for extracting `internal/diff` package from `internal/tui`.

- Move `worddiff.go` and `worddiff_test.go` from `internal/tui/` to `internal/diff/`
- Export types: `diffOp` → `Op`, `wordSpan` → `WordSpan` (with exported fields `Text`, `Op`)
- Export functions: `computeWordDiff` → `ComputeWordDiff`, `tokenize` → `Tokenize`
- Keep `isSpaceRune` as private helper
- Update references in `internal/tui/diffmodel.go` and `internal/tui/diffrender.go`

No functional changes. `diffRow`, `diffData`, `buildDiffData` and other diff-model types remain in `tui/` for the next PR.

## Test plan

- [x] `go build -o /dev/null ./cmd/gra/` passes
- [x] `go test ./...` passes (all packages including `internal/diff` and `internal/tui`)