### PR TITLE
test: enhance diff package test coverage

### DIFF
--- a/internal/diff/model_test.go
+++ b/internal/diff/model_test.go
@@ -219,3 +219,174 @@ func TestDetectHunks_NoChanges(t *testing.T) {
 		t.Fatalf("expected 0 hunks, got %d", len(d.Hunks))
 	}
 }
+
+func TestBuild_BothNil(t *testing.T) {
+	d := Build(nil, nil)
+
+	if len(d.Rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(d.Rows))
+	}
+	if len(d.Hunks) != 0 {
+		t.Errorf("expected 0 hunks, got %d", len(d.Hunks))
+	}
+	if d.Summary.Additions != 0 || d.Summary.Deletions != 0 || d.Summary.Modified != 0 {
+		t.Errorf("expected zero stats, got %+v", d.Summary)
+	}
+	if d.MaxLineNum != 0 {
+		t.Errorf("expected MaxLineNum 0, got %d", d.MaxLineNum)
+	}
+}
+
+func TestBuild_BothEmpty(t *testing.T) {
+	d := Build([]string{}, []string{})
+
+	if len(d.Rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(d.Rows))
+	}
+	if len(d.Hunks) != 0 {
+		t.Errorf("expected 0 hunks, got %d", len(d.Hunks))
+	}
+	if d.Summary.Additions != 0 || d.Summary.Deletions != 0 || d.Summary.Modified != 0 {
+		t.Errorf("expected zero stats, got %+v", d.Summary)
+	}
+	if d.MaxLineNum != 0 {
+		t.Errorf("expected MaxLineNum 0, got %d", d.MaxLineNum)
+	}
+}
+
+func TestBuild_WordDiffComputed(t *testing.T) {
+	old := []string{"hello world"}
+	new := []string{"hello earth"}
+	d := Build(old, new)
+
+	if len(d.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(d.Rows))
+	}
+	r := d.Rows[0]
+	if r.Type != RowModified {
+		t.Fatalf("expected RowModified, got %d", r.Type)
+	}
+	if r.OldSpans == nil {
+		t.Error("expected non-nil OldSpans for modified row")
+	}
+	if r.NewSpans == nil {
+		t.Error("expected non-nil NewSpans for modified row")
+	}
+
+	// Verify unchanged rows do NOT get word diff spans.
+	old2 := []string{"same", "changed"}
+	new2 := []string{"same", "CHANGED"}
+	d2 := Build(old2, new2)
+
+	for _, r := range d2.Rows {
+		if r.Type == RowUnchanged {
+			if r.OldSpans != nil || r.NewSpans != nil {
+				t.Error("unchanged row should have nil spans")
+			}
+		}
+	}
+}
+
+func TestBuild_MaxLineNum(t *testing.T) {
+	old := []string{"a", "b", "c"}
+	new := []string{"a", "b", "c"}
+	d := Build(old, new)
+
+	if d.MaxLineNum != 3 {
+		t.Errorf("expected MaxLineNum 3, got %d", d.MaxLineNum)
+	}
+
+	// When new side is longer, MaxLineNum should reflect it.
+	d2 := Build([]string{"a"}, []string{"a", "b", "c", "d", "e"})
+	if d2.MaxLineNum != 5 {
+		t.Errorf("expected MaxLineNum 5, got %d", d2.MaxLineNum)
+	}
+
+	// When old side is longer, MaxLineNum should reflect it.
+	d3 := Build([]string{"a", "b", "c", "d"}, []string{"a"})
+	if d3.MaxLineNum != 4 {
+		t.Errorf("expected MaxLineNum 4, got %d", d3.MaxLineNum)
+	}
+}
+
+func TestBuild_StandaloneInsert(t *testing.T) {
+	// Insert at the beginning (not preceded by deletes).
+	old := []string{"a", "b"}
+	new := []string{"x", "a", "b"}
+	d := Build(old, new)
+
+	foundAdded := false
+	for _, r := range d.Rows {
+		if r.Type == RowAdded && r.NewText == "x" {
+			foundAdded = true
+			if r.OldLineNum != 0 {
+				t.Errorf("standalone insert should have OldLineNum 0, got %d", r.OldLineNum)
+			}
+		}
+	}
+	if !foundAdded {
+		t.Error("expected to find a RowAdded for standalone insert 'x'")
+	}
+	if d.Summary.Additions < 1 {
+		t.Errorf("expected at least 1 addition, got %d", d.Summary.Additions)
+	}
+}
+
+func TestDetectHunks_EmptyRows(t *testing.T) {
+	hunks := DetectHunks(nil, 3)
+	if hunks != nil {
+		t.Errorf("expected nil hunks, got %v", hunks)
+	}
+
+	hunks2 := DetectHunks([]Row{}, 3)
+	if hunks2 != nil {
+		t.Errorf("expected nil hunks for empty slice, got %v", hunks2)
+	}
+}
+
+func TestDetectHunks_AllChanged(t *testing.T) {
+	rows := []Row{
+		{Type: RowModified},
+		{Type: RowAdded},
+		{Type: RowDeleted},
+		{Type: RowModified},
+	}
+	hunks := DetectHunks(rows, 3)
+
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	if hunks[0].StartIdx != 0 {
+		t.Errorf("expected StartIdx 0, got %d", hunks[0].StartIdx)
+	}
+	if hunks[0].EndIdx != 4 {
+		t.Errorf("expected EndIdx 4, got %d", hunks[0].EndIdx)
+	}
+}
+
+func TestDetectHunks_ContextZero(t *testing.T) {
+	rows := []Row{
+		{Type: RowUnchanged},
+		{Type: RowUnchanged},
+		{Type: RowModified},
+		{Type: RowUnchanged},
+		{Type: RowUnchanged},
+		{Type: RowUnchanged},
+		{Type: RowUnchanged},
+		{Type: RowDeleted},
+		{Type: RowUnchanged},
+	}
+	hunks := DetectHunks(rows, 0)
+
+	if len(hunks) != 2 {
+		t.Fatalf("expected 2 hunks with zero context, got %d", len(hunks))
+	}
+	// First hunk covers only the modified row.
+	if hunks[0].StartIdx != 2 || hunks[0].EndIdx != 3 {
+		t.Errorf("hunk[0]: expected [2,3), got [%d,%d)", hunks[0].StartIdx, hunks[0].EndIdx)
+	}
+	// Second hunk covers only the deleted row.
+	if hunks[1].StartIdx != 7 || hunks[1].EndIdx != 8 {
+		t.Errorf("hunk[1]: expected [7,8), got [%d,%d)", hunks[1].StartIdx, hunks[1].EndIdx)
+	}
+}

--- a/internal/diff/worddiff_test.go
+++ b/internal/diff/worddiff_test.go
@@ -180,6 +180,135 @@ func TestTokenize_TabsAndSpaces(t *testing.T) {
 	assertTokens(t, got, want)
 }
 
+func TestComputeWordDiff_EmptyStrings(t *testing.T) {
+	oldSpans, newSpans := ComputeWordDiff("", "")
+
+	if len(oldSpans) != 0 {
+		t.Errorf("expected 0 oldSpans, got %d", len(oldSpans))
+	}
+	if len(newSpans) != 0 {
+		t.Errorf("expected 0 newSpans, got %d", len(newSpans))
+	}
+}
+
+func TestComputeWordDiff_IdenticalStrings(t *testing.T) {
+	tests := []string{
+		"hello world",
+		"single",
+		"  spaced  out  ",
+		"\ttabbed",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			oldSpans, newSpans := ComputeWordDiff(input, input)
+
+			for i, s := range oldSpans {
+				if s.Op != OpEqual {
+					t.Errorf("oldSpans[%d]: expected OpEqual, got %d", i, s.Op)
+				}
+			}
+			for i, s := range newSpans {
+				if s.Op != OpEqual {
+					t.Errorf("newSpans[%d]: expected OpEqual, got %d", i, s.Op)
+				}
+			}
+
+			oldJoined := joinSpans(oldSpans)
+			newJoined := joinSpans(newSpans)
+			if oldJoined != input {
+				t.Errorf("old round-trip: expected %q, got %q", input, oldJoined)
+			}
+			if newJoined != input {
+				t.Errorf("new round-trip: expected %q, got %q", input, newJoined)
+			}
+		})
+	}
+}
+
+func TestComputeWordDiff_WhitespaceOnly(t *testing.T) {
+	oldSpans, newSpans := ComputeWordDiff("  ", "\t")
+
+	oldJoined := joinSpans(oldSpans)
+	newJoined := joinSpans(newSpans)
+	if oldJoined != "  " {
+		t.Errorf("old round-trip: expected %q, got %q", "  ", oldJoined)
+	}
+	if newJoined != "\t" {
+		t.Errorf("new round-trip: expected %q, got %q", "\t", newJoined)
+	}
+
+	// There should be a change since the whitespace differs.
+	hasDelete := false
+	for _, s := range oldSpans {
+		if s.Op == OpDelete {
+			hasDelete = true
+		}
+	}
+	hasInsert := false
+	for _, s := range newSpans {
+		if s.Op == OpInsert {
+			hasInsert = true
+		}
+	}
+	if !hasDelete {
+		t.Error("expected old side to have a delete span")
+	}
+	if !hasInsert {
+		t.Error("expected new side to have an insert span")
+	}
+}
+
+func TestComputeWordDiff_CJK(t *testing.T) {
+	oldSpans, newSpans := ComputeWordDiff("hello world", "hello world")
+
+	oldJoined := joinSpans(oldSpans)
+	newJoined := joinSpans(newSpans)
+	if oldJoined != "hello world" {
+		t.Errorf("old round-trip: expected %q, got %q", "hello world", oldJoined)
+	}
+	if newJoined != "hello world" {
+		t.Errorf("new round-trip: expected %q, got %q", "hello world", newJoined)
+	}
+
+	// Diff between CJK content.
+	oldSpans2, newSpans2 := ComputeWordDiff("func", "func")
+	oldJoined2 := joinSpansFiltered(oldSpans2, OpInsert)
+	newJoined2 := joinSpansFiltered(newSpans2, OpDelete)
+	if oldJoined2 != "func" {
+		t.Errorf("CJK diff old round-trip: expected %q, got %q",
+			"func", oldJoined2)
+	}
+	if newJoined2 != "func" {
+		t.Errorf("CJK diff new round-trip: expected %q, got %q",
+			"func", newJoined2)
+	}
+}
+
+func TestTokenize_SingleWord(t *testing.T) {
+	got := Tokenize("hello")
+	want := []string{"hello"}
+	assertTokens(t, got, want)
+}
+
+func TestTokenize_OnlySpaces(t *testing.T) {
+	got := Tokenize("   ")
+	want := []string{"   "}
+	assertTokens(t, got, want)
+}
+
+func TestTokenize_MixedWhitespace(t *testing.T) {
+	// Tabs and spaces are both whitespace, so adjacent
+	// tabs and spaces form a single whitespace token.
+	got := Tokenize("\t foo")
+	want := []string{"\t ", "foo"}
+	assertTokens(t, got, want)
+
+	// Non-whitespace separates whitespace tokens.
+	got2 := Tokenize("\ta b")
+	want2 := []string{"\t", "a", " ", "b"}
+	assertTokens(t, got2, want2)
+}
+
 // --- helpers ---
 
 func containsSpan(spans []WordSpan, text string, op Op) bool {


### PR DESCRIPTION
## Summary

- Add edge case tests for `Build()`: both-nil, both-empty, word diff computation on modified rows, MaxLineNum correctness, standalone inserts
- Add edge case tests for `DetectHunks()`: empty rows, all-changed single hunk, zero-context minimal hunks
- Add edge case tests for `ComputeWordDiff()`: both-empty strings, identical strings, whitespace-only diff, CJK characters
- Add edge case tests for `Tokenize()`: single word, only spaces, mixed whitespace (tabs + spaces)

## Test plan

- [x] `go test ./internal/diff/...` passes (41 tests)
- [x] `go test ./...` passes (all packages)
- [x] `make lint` reports 0 issues
- [x] No production code changes