### PR TITLE
feat: add viewed state tracking for git panel files

### DIFF
--- a/internal/tui/gitmode.go
+++ b/internal/tui/gitmode.go
@@ -45,7 +45,39 @@ type gitPanelState struct {
 	cursor           int
 	scrollOffset     int
 	loaded           bool
-	stale            bool // needs reload on next access
+	stale            bool            // needs reload on next access
+	viewed           map[string]bool // relative path -> viewed flag
+	viewedCount      int             // cached count of viewed entries
+}
+
+// toggleViewed flips the viewed state for the given file name.
+func (gs *gitPanelState) toggleViewed(name string) {
+	if gs.viewed == nil {
+		gs.viewed = make(map[string]bool)
+	}
+	if gs.viewed[name] {
+		gs.viewed[name] = false
+		gs.viewedCount--
+	} else {
+		gs.viewed[name] = true
+		gs.viewedCount++
+	}
+}
+
+// recomputeViewedCount recalculates the cached viewed count from scratch.
+// Called when entries are replaced (e.g. after git reload).
+func (gs *gitPanelState) recomputeViewedCount() {
+	gs.viewedCount = 0
+	for i := range gs.entries {
+		if gs.viewed[gs.entries[i].name] {
+			gs.viewedCount++
+		}
+	}
+}
+
+// viewedCountTotal returns (viewed, total) counts for all entries.
+func (gs *gitPanelState) viewedCountTotal() (int, int) {
+	return gs.viewedCount, len(gs.entries)
 }
 
 // switchGitMode changes the active git diff mode by delta (-1 or +1).

--- a/internal/tui/gitpanel.go
+++ b/internal/tui/gitpanel.go
@@ -151,7 +151,8 @@ func (m *Model) handleGitChangedFiles(msg gitChangedFilesMsg) (tea.Model, tea.Cm
 		return m, statusTickCmd()
 	}
 	gs.entries = msg.entries
-	gs.visualRows, gs.entryToVisualIdx = buildGitVisualRows(msg.entries)
+	gs.recomputeViewedCount()
+	gs.visualRows, gs.entryToVisualIdx = buildGitVisualRows(msg.entries, gs.viewed)
 	gs.loaded = true
 	gs.stale = false
 	m.gitAnyLoaded = true
@@ -171,7 +172,7 @@ func (m *Model) handleGitChangedFiles(msg gitChangedFilesMsg) (tea.Model, tea.Cm
 // with category headers and directory grouping.
 // Hierarchy: Category > Directory > File.
 // Also returns a reverse map from entryIdx to visual row index.
-func buildGitVisualRows(entries []changedFileEntry) ([]gitVisualRow, map[int]int) {
+func buildGitVisualRows(entries []changedFileEntry, viewed map[string]bool) ([]gitVisualRow, map[int]int) {
 	type section struct {
 		cat     fileCategory
 		label   string
@@ -208,10 +209,16 @@ func buildGitVisualRows(entries []changedFileEntry) ([]gitVisualRow, map[int]int
 			continue
 		}
 
-		// Category header.
+		// Category header with viewed count.
+		viewedInCat := 0
+		for _, idx := range sec.indices {
+			if viewed[entries[idx].name] {
+				viewedInCat++
+			}
+		}
 		rows = append(rows, gitVisualRow{
 			isHeader: true,
-			label:    fmt.Sprintf("  %s (%d)", sec.label, len(sec.indices)),
+			label:    fmt.Sprintf("  %s (%d/%d)", sec.label, viewedInCat, len(sec.indices)),
 		})
 
 		// Group entries by directory, preserving order of first appearance.
@@ -379,6 +386,7 @@ func (m *Model) renderGitPanel(width, height int) []string {
 
 		e := gs.entries[row.entryIdx]
 		isCursor := row.entryIdx == gs.cursor && m.focusPane == paneTree
+		isViewed := gs.viewed[e.name]
 
 		style := gitStatusStyles[e.status]
 		statusIcon := style.Render(e.status.String())
@@ -386,6 +394,9 @@ func (m *Model) renderGitPanel(width, height int) []string {
 		displayLine := ansi.Truncate(line, width, "...")
 		displayLine = render.PadRight(displayLine, width)
 
+		if isViewed && !isCursor {
+			displayLine = styleDirHeader.Render(displayLine)
+		}
 		if isCursor {
 			displayLine = styleTreeCursor(m.theme).Render(displayLine)
 		}
@@ -435,6 +446,62 @@ func firstGitEntryIdx(rows []gitVisualRow) int {
 		}
 	}
 	return 0
+}
+
+// findUnviewedEntry searches for the nearest unviewed entry in the given
+// direction (1 for next, -1 for previous). Wraps around.
+// Returns -1 if all entries are viewed.
+func (gs *gitPanelState) findUnviewedEntry(from, dir int) int {
+	n := len(gs.entries)
+	if n == 0 {
+		return -1
+	}
+	for i := 1; i <= n; i++ {
+		idx := (from + i*dir%n + n) % n
+		if !gs.viewed[gs.entries[idx].name] {
+			return idx
+		}
+	}
+	return -1
+}
+
+// navigateUnviewed jumps to the next/prev unviewed file and opens its diff tab.
+func (m *Model) navigateUnviewed(dir int) (tea.Model, tea.Cmd) {
+	gs := m.gitState()
+	if len(gs.entries) == 0 {
+		return m, nil
+	}
+
+	// Determine starting position.
+	from := gs.cursor
+	if t, ok := m.activeTabState(); ok && t.hasGitDiffModeTag {
+		for i := range gs.entries {
+			if gs.entries[i].absPath == t.filePath {
+				from = i
+				break
+			}
+		}
+	}
+
+	target := gs.findUnviewedEntry(from, dir)
+	if target < 0 {
+		m.statusMsg = "All files viewed"
+		return m, statusTickCmd()
+	}
+
+	gs.cursor = target
+	m.openGitDiffEntry()
+	// Adjust git panel scroll for the new cursor.
+	if idx, ok := gs.entryToVisualIdx[gs.cursor]; ok {
+		lo := m.computeLayout()
+		panelHeight := lo.contentHeight - 1
+		if panelHeight > 0 && idx >= gs.scrollOffset+panelHeight {
+			gs.scrollOffset = idx - panelHeight + 1
+		} else if idx < gs.scrollOffset {
+			gs.scrollOffset = idx
+		}
+	}
+	return m, nil
 }
 
 // lastGitEntryIdx returns the entryIdx of the last file row.

--- a/internal/tui/gitpanel_test.go
+++ b/internal/tui/gitpanel_test.go
@@ -71,7 +71,7 @@ func setGitEntries(m *Model, entries []changedFileEntry) {
 	fillPathFields(entries)
 	gs := m.gitState()
 	gs.entries = entries
-	gs.visualRows, gs.entryToVisualIdx = buildGitVisualRows(entries)
+	gs.visualRows, gs.entryToVisualIdx = buildGitVisualRows(entries, nil)
 	gs.cursor = 0
 	gs.loaded = true
 }
@@ -307,7 +307,7 @@ func TestBuildGitVisualRows(t *testing.T) {
 		{name: "unstaged.go", status: git.StatusModified, category: categoryUnstaged},
 		{name: "untracked.go", status: git.StatusUntracked, category: categoryUntracked},
 	})
-	rows, reverseMap := buildGitVisualRows(entries)
+	rows, reverseMap := buildGitVisualRows(entries, nil)
 
 	// 3 category headers + 3 dir headers (./) + 3 files = 9 rows
 	if len(rows) != 9 {
@@ -345,7 +345,7 @@ func TestBuildGitVisualRows_EmptySection(t *testing.T) {
 	entries := fillPathFields([]changedFileEntry{
 		{name: "a.go", status: git.StatusModified, category: categoryUnstaged},
 	})
-	rows, _ := buildGitVisualRows(entries)
+	rows, _ := buildGitVisualRows(entries, nil)
 	// Only unstaged: 1 category header + 1 dir header (./) + 1 file
 	if len(rows) != 3 {
 		t.Fatalf("expected 3 rows, got %d", len(rows))
@@ -506,7 +506,7 @@ func TestBuildGitVisualRows_DirGrouping(t *testing.T) {
 		{name: "internal/git/status.go", status: git.StatusModified, category: categoryUnstaged},
 		{name: "internal/tui/model.go", status: git.StatusModified, category: categoryUnstaged},
 	})
-	rows, reverseMap := buildGitVisualRows(entries)
+	rows, reverseMap := buildGitVisualRows(entries, nil)
 
 	// 1 category header + 2 dir headers + 3 files = 6 rows
 	if len(rows) != 6 {
@@ -549,7 +549,7 @@ func TestBuildGitVisualRows_MixedRootAndDir(t *testing.T) {
 		{name: "go.mod", status: git.StatusModified, category: categoryUnstaged},
 		{name: "internal/tui/model.go", status: git.StatusModified, category: categoryUnstaged},
 	})
-	rows, _ := buildGitVisualRows(entries)
+	rows, _ := buildGitVisualRows(entries, nil)
 
 	// 1 category header + 1 dir header (./) + 1 file + 1 dir header + 1 file = 5 rows
 	if len(rows) != 5 {
@@ -583,7 +583,7 @@ func TestBuildGitVisualRows_DirGroupingMultiCategory(t *testing.T) {
 		{name: "internal/git/diff.go", status: git.StatusModified, category: categoryStaged},
 		{name: "internal/git/status.go", status: git.StatusModified, category: categoryUnstaged},
 	})
-	rows, _ := buildGitVisualRows(entries)
+	rows, _ := buildGitVisualRows(entries, nil)
 
 	// Staged: 1 cat header + 1 dir header + 1 file = 3
 	// Unstaged: 1 cat header + 1 dir header + 1 file = 3
@@ -756,6 +756,225 @@ func TestAutoOpenFirstDiff_OnlyOnce(t *testing.T) {
 
 	if len(m.tabs) != 0 {
 		t.Fatalf("expected 0 tabs (auto-open should not fire again), got %d", len(m.tabs))
+	}
+}
+
+func TestToggleViewed(t *testing.T) {
+	m := newTestModel(t)
+	m.focusPane = paneTree
+	m.activePanel = panelGitDiff
+
+	setGitEntries(m, []changedFileEntry{
+		{name: "a.go", status: git.StatusModified, category: categoryUnstaged},
+		{name: "b.go", status: git.StatusAdded, category: categoryUnstaged},
+	})
+
+	gs := m.gitState()
+	gs.cursor = 0
+
+	// Toggle viewed on first file via V key.
+	m.Update(tea.KeyPressMsg{Code: 'V', Text: "V"})
+	if !gs.viewed["a.go"] {
+		t.Error("expected a.go to be viewed after toggle")
+	}
+
+	// Toggle again to unview.
+	m.Update(tea.KeyPressMsg{Code: 'V', Text: "V"})
+	if gs.viewed["a.go"] {
+		t.Error("expected a.go to be unviewed after second toggle")
+	}
+}
+
+func TestToggleViewed_LazyInit(t *testing.T) {
+	var gs gitPanelState
+	gs.entries = []changedFileEntry{{name: "x.go"}}
+	if gs.viewed != nil {
+		t.Fatal("expected nil viewed map initially")
+	}
+	gs.toggleViewed("x.go")
+	if gs.viewed == nil {
+		t.Fatal("expected viewed map to be initialized")
+	}
+	if !gs.viewed["x.go"] {
+		t.Error("expected x.go to be viewed")
+	}
+}
+
+func TestFindUnviewedEntry_Next(t *testing.T) {
+	gs := &gitPanelState{
+		entries: fillPathFields([]changedFileEntry{
+			{name: "a.go"}, {name: "b.go"}, {name: "c.go"},
+		}),
+		viewed: map[string]bool{"b.go": true},
+	}
+
+	// From 0, next unviewed should skip b.go (1) and return c.go (2).
+	if got := gs.findUnviewedEntry(0, 1); got != 2 {
+		t.Errorf("expected 2, got %d", got)
+	}
+
+	// From 2, next unviewed should wrap to a.go (0).
+	if got := gs.findUnviewedEntry(2, 1); got != 0 {
+		t.Errorf("expected 0 (wrap), got %d", got)
+	}
+}
+
+func TestFindUnviewedEntry_Prev(t *testing.T) {
+	gs := &gitPanelState{
+		entries: fillPathFields([]changedFileEntry{
+			{name: "a.go"}, {name: "b.go"}, {name: "c.go"},
+		}),
+		viewed: map[string]bool{"b.go": true},
+	}
+
+	// From 2, prev unviewed should skip b.go (1) and return a.go (0).
+	if got := gs.findUnviewedEntry(2, -1); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+
+	// From 0, prev unviewed should wrap to c.go (2).
+	if got := gs.findUnviewedEntry(0, -1); got != 2 {
+		t.Errorf("expected 2 (wrap), got %d", got)
+	}
+}
+
+func TestFindUnviewedEntry_AllViewed(t *testing.T) {
+	gs := &gitPanelState{
+		entries: fillPathFields([]changedFileEntry{
+			{name: "a.go"}, {name: "b.go"},
+		}),
+		viewed: map[string]bool{"a.go": true, "b.go": true},
+	}
+	if got := gs.findUnviewedEntry(0, 1); got != -1 {
+		t.Errorf("expected -1 when all viewed, got %d", got)
+	}
+	if got := gs.findUnviewedEntry(0, -1); got != -1 {
+		t.Errorf("expected -1 when all viewed, got %d", got)
+	}
+}
+
+func TestViewedCountTotal(t *testing.T) {
+	gs := &gitPanelState{
+		entries: fillPathFields([]changedFileEntry{
+			{name: "a.go"}, {name: "b.go"}, {name: "c.go"},
+		}),
+	}
+	gs.toggleViewed("a.go")
+	gs.toggleViewed("c.go")
+	v, total := gs.viewedCountTotal()
+	if v != 2 || total != 3 {
+		t.Errorf("expected (2, 3), got (%d, %d)", v, total)
+	}
+}
+
+func TestBuildGitVisualRows_ViewedCount(t *testing.T) {
+	entries := fillPathFields([]changedFileEntry{
+		{name: "a.go", status: git.StatusModified, category: categoryUnstaged},
+		{name: "b.go", status: git.StatusAdded, category: categoryUnstaged},
+		{name: "c.go", status: git.StatusModified, category: categoryUnstaged},
+	})
+	viewed := map[string]bool{"a.go": true, "c.go": true}
+	rows, _ := buildGitVisualRows(entries, viewed)
+
+	// First row is category header with viewed count.
+	if !rows[0].isHeader {
+		t.Fatal("expected category header at row 0")
+	}
+	want := "  Changes (2/3)"
+	if rows[0].label != want {
+		t.Errorf("expected label %q, got %q", want, rows[0].label)
+	}
+}
+
+func TestNavigateUnviewed_FromGitPanel(t *testing.T) {
+	m := newTestModel(t)
+	m.focusPane = paneTree
+	m.activePanel = panelGitDiff
+
+	setGitEntries(m, []changedFileEntry{
+		{name: "a.go", status: git.StatusModified, absPath: "/tmp/a.go",
+			oldContent: []string{"old"}, newContent: []string{"new"}, category: categoryUnstaged},
+		{name: "b.go", status: git.StatusModified, absPath: "/tmp/b.go",
+			oldContent: []string{"old"}, newContent: []string{"new"}, category: categoryUnstaged},
+		{name: "c.go", status: git.StatusModified, absPath: "/tmp/c.go",
+			oldContent: []string{"old"}, newContent: []string{"new"}, category: categoryUnstaged},
+	})
+
+	gs := m.gitState()
+	gs.viewed = map[string]bool{"b.go": true}
+	gs.cursor = 0
+
+	// NextUnviewed from 0 should skip b.go and go to c.go (2).
+	m.navigateUnviewed(1)
+	if gs.cursor != 2 {
+		t.Errorf("expected cursor=2, got %d", gs.cursor)
+	}
+	if len(m.tabs) != 1 {
+		t.Fatalf("expected 1 tab opened, got %d", len(m.tabs))
+	}
+	if m.tabs[0].filePath != "/tmp/c.go" {
+		t.Errorf("expected tab for c.go, got %s", m.tabs[0].filePath)
+	}
+}
+
+func TestNavigateUnviewed_FromDiffView(t *testing.T) {
+	m := newTestModel(t)
+	m.activePanel = panelGitDiff
+
+	setGitEntries(m, []changedFileEntry{
+		{name: "a.go", status: git.StatusModified, absPath: "/tmp/a.go",
+			oldContent: []string{"old"}, newContent: []string{"new"}, category: categoryUnstaged},
+		{name: "b.go", status: git.StatusModified, absPath: "/tmp/b.go",
+			oldContent: []string{"old"}, newContent: []string{"new"}, category: categoryUnstaged},
+	})
+
+	// Open a diff tab for a.go to simulate being in diff view.
+	gs := m.gitState()
+	gs.cursor = 0
+	m.openGitDiffEntry()
+	if len(m.tabs) != 1 {
+		t.Fatalf("expected 1 tab, got %d", len(m.tabs))
+	}
+
+	gs.viewed = map[string]bool{"a.go": true}
+
+	// Navigate next unviewed from diff view (current file a.go).
+	m.navigateUnviewed(1)
+	if gs.cursor != 1 {
+		t.Errorf("expected cursor=1, got %d", gs.cursor)
+	}
+	if len(m.tabs) != 2 {
+		t.Fatalf("expected 2 tabs, got %d", len(m.tabs))
+	}
+}
+
+func TestViewedPersistsAcrossReload(t *testing.T) {
+	m := newTestModel(t)
+	m.activePanel = panelGitDiff
+
+	entries := fillPathFields([]changedFileEntry{
+		{name: "a.go", status: git.StatusModified, category: categoryUnstaged},
+		{name: "b.go", status: git.StatusAdded, category: categoryUnstaged},
+	})
+
+	m.Update(gitChangedFilesMsg{mode: gitModeWorking, entries: entries})
+	gs := m.gitState()
+	gs.toggleViewed("a.go")
+
+	if !gs.viewed["a.go"] {
+		t.Fatal("expected a.go viewed before reload")
+	}
+
+	// Simulate reload with new entries.
+	entries2 := fillPathFields([]changedFileEntry{
+		{name: "a.go", status: git.StatusModified, category: categoryUnstaged},
+		{name: "c.go", status: git.StatusAdded, category: categoryUnstaged},
+	})
+	m.Update(gitChangedFilesMsg{mode: gitModeWorking, entries: entries2})
+
+	gs = m.gitState()
+	if !gs.viewed["a.go"] {
+		t.Error("expected a.go viewed to persist after reload")
 	}
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -37,6 +37,9 @@ type keyMap struct {
 	Search        key.Binding
 	SearchNext    key.Binding
 	SearchPrev    key.Binding
+	ToggleViewed  key.Binding
+	NextUnviewed  key.Binding
+	PrevUnviewed  key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -164,6 +167,18 @@ func newKeyMap() keyMap {
 			key.WithKeys("N"),
 			key.WithHelp("N", "prev match"),
 		),
+		ToggleViewed: key.NewBinding(
+			key.WithKeys("V"),
+			key.WithHelp("V", "toggle viewed"),
+		),
+		NextUnviewed: key.NewBinding(
+			key.WithKeys(")"),
+			key.WithHelp(")", "next unviewed"),
+		),
+		PrevUnviewed: key.NewBinding(
+			key.WithKeys("("),
+			key.WithHelp("(", "prev unviewed"),
+		),
 	}
 }
 
@@ -173,6 +188,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 		k.SwitchPane, k.SwitchPanel, k.ToggleSidebar,
 		k.PrevTab, k.NextTab, k.CloseTab,
 		k.Select, k.Copy, k.OpenFile, k.Search,
+		k.ToggleViewed, k.NextUnviewed, k.PrevUnviewed,
 		k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit,
 	}
 }
@@ -182,7 +198,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right, k.GoTop, k.GoBottom, k.BlockUp, k.BlockDown, k.ChangeUp, k.ChangeDown},
 		{k.Enter, k.SwitchPane, k.SwitchPanel, k.ToggleSidebar, k.PrevTab, k.NextTab, k.CloseTab},
-		{k.Select, k.Copy, k.Comment, k.ClearAll, k.OpenFile, k.Search, k.SearchNext, k.SearchPrev, k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit},
+		{k.Select, k.Copy, k.Comment, k.ClearAll, k.OpenFile, k.Search, k.SearchNext, k.SearchPrev, k.ToggleViewed, k.NextUnviewed, k.PrevUnviewed, k.AcceptDiff, k.RejectDiff, k.Cancel, k.Quit},
 	}
 }
 
@@ -213,5 +229,10 @@ func (m *Model) contextKeyMap() help.KeyMap {
 	km.Search.SetEnabled(hasTab)
 	km.SearchNext.SetEnabled(m.search.query != "")
 	km.SearchPrev.SetEnabled(m.search.query != "")
+	isGitPanel := m.activePanel == panelGitDiff
+	isGitDiffTab := hasTab && t.hasGitDiffModeTag
+	km.ToggleViewed.SetEnabled(isGitPanel && m.focusPane == paneTree)
+	km.NextUnviewed.SetEnabled(isGitPanel || isGitDiffTab)
+	km.PrevUnviewed.SetEnabled(isGitPanel || isGitDiffTab)
 	return km
 }

--- a/internal/tui/update_key.go
+++ b/internal/tui/update_key.go
@@ -843,6 +843,19 @@ func (m *Model) handleKeyNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.gPending = true
 	case key.Matches(msg, m.keys.OpenFile):
 		return m, m.openFile.open(m.rootDir, m.excludeFunc)
+	case key.Matches(msg, m.keys.ToggleViewed):
+		if m.focusPane == paneTree && m.activePanel == panelGitDiff {
+			gs := m.gitState()
+			if gs.cursor >= 0 && gs.cursor < len(gs.entries) {
+				gs.toggleViewed(gs.entries[gs.cursor].name)
+				gs.visualRows, gs.entryToVisualIdx =
+					buildGitVisualRows(gs.entries, gs.viewed)
+			}
+		}
+	case key.Matches(msg, m.keys.NextUnviewed):
+		return m.navigateUnviewed(1)
+	case key.Matches(msg, m.keys.PrevUnviewed):
+		return m.navigateUnviewed(-1)
 	case key.Matches(msg, m.keys.Search):
 		if hasTab {
 			m.startSearch()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -452,7 +452,17 @@ func (m *Model) renderFooter() string {
 func (m *Model) renderLeftPane(width, height int) []string {
 	var header string
 	if m.activePanel == panelGitDiff {
-		label := m.activePanel.label() + " \u276e" + m.gitDiffMode.label(m.gitDefaultBranch) + "\u276f"
+		gs := m.gitState()
+		v, total := gs.viewedCountTotal()
+		modeLabel := m.gitDiffMode.label(m.gitDefaultBranch)
+		var label string
+		if total > 0 {
+			label = fmt.Sprintf("%s \u276e%s\u276f %d/%d",
+				m.activePanel.label(), modeLabel, v, total)
+		} else {
+			label = fmt.Sprintf("%s \u276e%s\u276f",
+				m.activePanel.label(), modeLabel)
+		}
 		header = renderPanelHeader(label, width, m.theme)
 	} else {
 		header = renderPanelHeader(m.activePanel.label(), width, m.theme)


### PR DESCRIPTION
## Overview

Add GitHub-style "Viewed" tracking to the git panel for review progress visualization.

## Why

When reviewing diffs in the git panel, there is no way to track which files have already been reviewed. This makes it difficult to manage review progress, especially for branches with many changed files.

## What

- `V` key toggles viewed state on the cursor file in the git panel
- `)` / `(` navigate to next/prev unviewed file (works in both git panel and diff view), opening the diff tab automatically
- Viewed files are rendered with faint styling for visual distinction
- Category headers show viewed count: `Changes (2/5)`
- Panel header shows total progress: `Git Changes ❮vs main❯ 3/5`
- Viewed state is in-memory per session (no persistence) and survives git panel reloads since the map is keyed by relative path
- Cached viewed count avoids per-frame O(n) iteration over entries

### Changed files

- `internal/tui/gitmode.go` - `viewed` map + `viewedCount` cache on `gitPanelState`, `toggleViewed`, `recomputeViewedCount`, `viewedCountTotal` helpers
- `internal/tui/keys.go` - `ToggleViewed` (V), `NextUnviewed` ()), `PrevUnviewed` (() key bindings with context-aware enable/disable
- `internal/tui/gitpanel.go` - `buildGitVisualRows` accepts viewed map for category header counts, `findUnviewedEntry` unified directional search, `navigateUnviewed` jump + open logic, faint styling for viewed files
- `internal/tui/view.go` - Panel header progress display (`N/M` format)
- `internal/tui/update_key.go` - Key dispatch for toggle, next/prev unviewed
- `internal/tui/gitpanel_test.go` - 10 new tests covering toggle, navigation, counting, persistence across reload

## Type of Change

- [x] Feature

## How to Test

1. `go build -o out/gra ./cmd/gra/` and run on a repo with branch changes
2. Open the git panel (Shift+Tab to switch to Git Changes)
3. Navigate to a file and press `V` to mark as viewed — file should appear faint
4. Press `)` to jump to the next unviewed file (opens diff tab)
5. Press `(` to jump to the previous unviewed file
6. Verify category headers show `(viewed/total)` format
7. Verify panel header shows total progress
8. Switch git diff modes and verify viewed state persists

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed