### PR TITLE
feat: implement compact folders for single-child directory chains

### DIFF
--- a/internal/tui/filetree.go
+++ b/internal/tui/filetree.go
@@ -17,13 +17,14 @@ type ExcludeFunc func(paths []string) map[string]bool
 
 // fileEntry represents a single entry in the file tree.
 type fileEntry struct {
-	path         string
-	name         string
-	isDir        bool
-	isBinary     bool
-	depth        int
-	expanded     bool
-	resolvedPath string // symlink target path (empty if not a symlink)
+	path           string
+	name           string
+	isDir          bool
+	isBinary       bool
+	depth          int
+	expanded       bool
+	resolvedPath   string   // symlink target path (empty if not a symlink)
+	compactedPaths []string // intermediate directory paths (shallow→deep) for compact folders
 }
 
 // TODO: make configurable (e.g. .gitignore or config file)
@@ -130,20 +131,26 @@ func buildFileTree(rootDir string) []fileEntry {
 	return entries
 }
 
-// scanDir scans a single directory level and returns entries.
-// When exclude is non-nil, it is used for batch gitignore filtering.
-// When exclude is nil, isHiddenEntry is used as fallback.
-func scanDir(dir string, depth int, entries []fileEntry, exclude ExcludeFunc) []fileEntry {
+// dirEntryInfo holds resolved metadata for a single directory entry.
+type dirEntryInfo struct {
+	entry        os.DirEntry
+	fullPath     string
+	resolvedPath string // non-empty for symlinks
+	isDir        bool
+}
+
+// dirContents holds the partitioned and sorted contents of a directory.
+type dirContents struct {
+	dirs         []dirEntryInfo
+	regularFiles []dirEntryInfo
+}
+
+// listDirContents reads a directory, resolves symlinks, applies exclusion
+// filtering, and returns the contents partitioned into dirs and files.
+func listDirContents(dir string, exclude ExcludeFunc) dirContents {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		return entries
-	}
-
-	type dirEntryInfo struct {
-		entry        os.DirEntry
-		fullPath     string
-		resolvedPath string // non-empty for symlinks
-		isDir        bool
+		return dirContents{}
 	}
 
 	// Collect all entries, resolve symlinks, compute fullPath.
@@ -188,7 +195,7 @@ func scanDir(dir string, depth int, entries []fileEntry, exclude ExcludeFunc) []
 	}
 
 	// Partition into dirs and files, skipping excluded.
-	var dirs, regularFiles []dirEntryInfo
+	var dc dirContents
 	for i := range allEntries {
 		e := &allEntries[i]
 		if exclude != nil {
@@ -203,31 +210,66 @@ func scanDir(dir string, depth int, entries []fileEntry, exclude ExcludeFunc) []
 			continue
 		}
 		if e.isDir {
-			dirs = append(dirs, *e)
+			dc.dirs = append(dc.dirs, *e)
 		} else {
-			regularFiles = append(regularFiles, *e)
+			dc.regularFiles = append(dc.regularFiles, *e)
 		}
 	}
 
-	slices.SortFunc(dirs, func(a, b dirEntryInfo) int {
+	slices.SortFunc(dc.dirs, func(a, b dirEntryInfo) int {
 		return strings.Compare(a.entry.Name(), b.entry.Name())
 	})
-	slices.SortFunc(regularFiles, func(a, b dirEntryInfo) int {
+	slices.SortFunc(dc.regularFiles, func(a, b dirEntryInfo) int {
 		return strings.Compare(a.entry.Name(), b.entry.Name())
 	})
 
-	for _, d := range dirs {
+	return dc
+}
+
+// compactSingleChildDirs follows a chain of directories where each has
+// exactly one subdirectory and no files, returning the compacted display
+// name (e.g. "a/b/c"), the leaf directory path, and intermediate paths.
+func compactSingleChildDirs(
+	dirPath, name string, exclude ExcludeFunc,
+) (compactedName, leafPath string, intermediates []string) {
+	compactedName = name
+	leafPath = dirPath
+
+	for {
+		dc := listDirContents(leafPath, exclude)
+		if len(dc.dirs) != 1 || len(dc.regularFiles) != 0 {
+			break
+		}
+		intermediates = append(intermediates, leafPath)
+		child := dc.dirs[0]
+		leafPath = child.fullPath
+		compactedName += "/" + child.entry.Name()
+	}
+
+	return compactedName, leafPath, intermediates
+}
+
+// scanDir scans a single directory level and returns entries.
+// When exclude is non-nil, it is used for batch gitignore filtering.
+// When exclude is nil, isHiddenEntry is used as fallback.
+func scanDir(dir string, depth int, entries []fileEntry, exclude ExcludeFunc) []fileEntry {
+	dc := listDirContents(dir, exclude)
+
+	for _, d := range dc.dirs {
+		cName, leafPath, intermediates := compactSingleChildDirs(
+			d.fullPath, d.entry.Name(), exclude)
 		entries = append(entries, fileEntry{
-			path:         d.fullPath,
-			name:         d.entry.Name(),
-			isDir:        true,
-			depth:        depth,
-			expanded:     false,
-			resolvedPath: d.resolvedPath,
+			path:           leafPath,
+			name:           cName,
+			isDir:          true,
+			depth:          depth,
+			expanded:       false,
+			resolvedPath:   d.resolvedPath,
+			compactedPaths: intermediates,
 		})
 	}
 
-	for _, f := range regularFiles {
+	for _, f := range dc.regularFiles {
 		entries = append(entries, fileEntry{
 			path:         f.fullPath,
 			name:         f.entry.Name(),
@@ -242,11 +284,16 @@ func scanDir(dir string, depth int, entries []fileEntry, exclude ExcludeFunc) []
 }
 
 // expandedPaths returns the set of currently expanded directory paths.
+// Intermediate paths from compacted entries are included so that
+// restore works correctly when the chain structure changes.
 func expandedPaths(entries []fileEntry) map[string]bool {
 	paths := make(map[string]bool)
 	for _, e := range entries {
 		if e.isDir && e.expanded {
 			paths[e.path] = true
+			for _, cp := range e.compactedPaths {
+				paths[cp] = true
+			}
 		}
 	}
 	return paths
@@ -257,11 +304,25 @@ func restoreExpanded(
 	entries []fileEntry, paths map[string]bool,
 ) []fileEntry {
 	for i := 0; i < len(entries); i++ {
-		if entries[i].isDir && paths[entries[i].path] {
+		if entries[i].isDir && shouldRestore(entries[i], paths) {
 			entries = expandDir(entries, i)
 		}
 	}
 	return entries
+}
+
+// shouldRestore returns true if the entry's path or any of its
+// compacted intermediate paths appear in the expanded set.
+func shouldRestore(e fileEntry, paths map[string]bool) bool {
+	if paths[e.path] {
+		return true
+	}
+	for _, cp := range e.compactedPaths {
+		if paths[cp] {
+			return true
+		}
+	}
+	return false
 }
 
 // expandDir expands a directory entry and inserts its children.

--- a/internal/tui/filetree_test.go
+++ b/internal/tui/filetree_test.go
@@ -150,3 +150,292 @@ func TestBuildFileTree_SymlinkLoop(t *testing.T) {
 		t.Errorf("expected 0 entries for symlink loop, got %d", len(entries))
 	}
 }
+
+// mkdirs creates nested directories under root.
+func mkdirs(t *testing.T, paths ...string) {
+	t.Helper()
+	for _, p := range paths {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// touch creates an empty file at path.
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCompactSingleChildDirs(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a/b/c with a file in c
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	name, leaf, intermediates := compactSingleChildDirs(
+		filepath.Join(tmp, "a"), "a", nil)
+
+	if name != "a/b/c" {
+		t.Errorf("want name %q, got %q", "a/b/c", name)
+	}
+	if leaf != filepath.Join(tmp, "a", "b", "c") {
+		t.Errorf("want leaf %q, got %q",
+			filepath.Join(tmp, "a", "b", "c"), leaf)
+	}
+	if len(intermediates) != 2 {
+		t.Fatalf("want 2 intermediates, got %d", len(intermediates))
+	}
+	if intermediates[0] != filepath.Join(tmp, "a") {
+		t.Errorf("intermediates[0]: want %q, got %q",
+			filepath.Join(tmp, "a"), intermediates[0])
+	}
+	if intermediates[1] != filepath.Join(tmp, "a", "b") {
+		t.Errorf("intermediates[1]: want %q, got %q",
+			filepath.Join(tmp, "a", "b"), intermediates[1])
+	}
+}
+
+func TestCompactSingleChildDirs_StopsAtFiles(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a/b where b has a file sibling in a
+	mkdirs(t, filepath.Join(tmp, "a", "b"))
+	touch(t, filepath.Join(tmp, "a", "readme.txt"))
+
+	name, leaf, intermediates := compactSingleChildDirs(
+		filepath.Join(tmp, "a"), "a", nil)
+
+	if name != "a" {
+		t.Errorf("want name %q, got %q", "a", name)
+	}
+	if leaf != filepath.Join(tmp, "a") {
+		t.Errorf("want leaf %q, got %q",
+			filepath.Join(tmp, "a"), leaf)
+	}
+	if len(intermediates) != 0 {
+		t.Errorf("want 0 intermediates, got %d", len(intermediates))
+	}
+}
+
+func TestCompactSingleChildDirs_StopsAtMultipleDirs(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a contains two subdirs
+	mkdirs(t, filepath.Join(tmp, "a", "x"))
+	mkdirs(t, filepath.Join(tmp, "a", "y"))
+
+	name, leaf, intermediates := compactSingleChildDirs(
+		filepath.Join(tmp, "a"), "a", nil)
+
+	if name != "a" {
+		t.Errorf("want name %q, got %q", "a", name)
+	}
+	if leaf != filepath.Join(tmp, "a") {
+		t.Errorf("want leaf %q, got %q",
+			filepath.Join(tmp, "a"), leaf)
+	}
+	if len(intermediates) != 0 {
+		t.Errorf("want 0 intermediates, got %d", len(intermediates))
+	}
+}
+
+func TestCompactSingleChildDirs_NoCompaction(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a has a file and a dir
+	mkdirs(t, filepath.Join(tmp, "a", "sub"))
+	touch(t, filepath.Join(tmp, "a", "file.txt"))
+
+	name, leaf, intermediates := compactSingleChildDirs(
+		filepath.Join(tmp, "a"), "a", nil)
+
+	if name != "a" {
+		t.Errorf("want name %q, got %q", "a", name)
+	}
+	if leaf != filepath.Join(tmp, "a") {
+		t.Errorf("want leaf unchanged")
+	}
+	if len(intermediates) != 0 {
+		t.Errorf("want 0 intermediates, got %d", len(intermediates))
+	}
+}
+
+func TestCompactSingleChildDirs_EmptyDir(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	mkdirs(t, filepath.Join(tmp, "empty"))
+
+	name, leaf, intermediates := compactSingleChildDirs(
+		filepath.Join(tmp, "empty"), "empty", nil)
+
+	if name != "empty" {
+		t.Errorf("want name %q, got %q", "empty", name)
+	}
+	if leaf != filepath.Join(tmp, "empty") {
+		t.Errorf("want leaf unchanged")
+	}
+	if len(intermediates) != 0 {
+		t.Errorf("want 0 intermediates, got %d", len(intermediates))
+	}
+}
+
+func TestScanDir_CompactedEntry(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a/b/c/file.txt — should compact to "a/b/c"
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	entries := scanDir(tmp, 0, nil, nil)
+
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d: %+v", len(entries), entries)
+	}
+	e := entries[0]
+	if e.name != "a/b/c" {
+		t.Errorf("want name %q, got %q", "a/b/c", e.name)
+	}
+	if e.path != filepath.Join(tmp, "a", "b", "c") {
+		t.Errorf("want path %q, got %q",
+			filepath.Join(tmp, "a", "b", "c"), e.path)
+	}
+	if !e.isDir {
+		t.Error("want isDir=true")
+	}
+	if len(e.compactedPaths) != 2 {
+		t.Errorf("want 2 compactedPaths, got %d", len(e.compactedPaths))
+	}
+}
+
+func TestExpandDir_CompactedEntry(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a/b/c/file.txt
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	entries := scanDir(tmp, 0, nil, nil)
+	entries = expandDir(entries, 0)
+
+	// Should show: a/b/c (expanded), file.txt
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries after expand, got %d: %+v",
+			len(entries), entries)
+	}
+	if entries[0].name != "a/b/c" || !entries[0].expanded {
+		t.Errorf("first entry: want expanded a/b/c, got %q expanded=%v",
+			entries[0].name, entries[0].expanded)
+	}
+	if entries[1].name != "file.txt" {
+		t.Errorf("second entry: want file.txt, got %q", entries[1].name)
+	}
+}
+
+func TestCollapseDir_CompactedEntry(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// a/b/c/file.txt
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	entries := scanDir(tmp, 0, nil, nil)
+	entries = expandDir(entries, 0)
+	entries = collapseDir(entries, 0)
+
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry after collapse, got %d", len(entries))
+	}
+	if entries[0].expanded {
+		t.Error("entry should not be expanded after collapse")
+	}
+	if entries[0].name != "a/b/c" {
+		t.Errorf("want name %q, got %q", "a/b/c", entries[0].name)
+	}
+}
+
+func TestRestoreExpanded_ChainBreaks(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// Start with a/b/c (compacted, expanded)
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	entries := scanDir(tmp, 0, nil, nil)
+	entries = expandDir(entries, 0)
+	paths := expandedPaths(entries)
+
+	// Break the chain: add a file to a/ so a won't compact anymore
+	touch(t, filepath.Join(tmp, "a", "extra.txt"))
+
+	// Rebuild and restore
+	var newEntries []fileEntry
+	newEntries = scanDir(tmp, 0, newEntries, nil)
+	newEntries = restoreExpanded(newEntries, paths)
+
+	// "a" should now be expanded (it was in compactedPaths)
+	if len(newEntries) == 0 {
+		t.Fatal("expected entries after rebuild")
+	}
+	if newEntries[0].name != "a" {
+		t.Errorf("want name %q, got %q", "a", newEntries[0].name)
+	}
+	if !newEntries[0].expanded {
+		t.Error("a should be restored to expanded state")
+	}
+}
+
+func TestRestoreExpanded_ChainForms(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	// Start with a (not compacted because b has a sibling file)
+	mkdirs(t, filepath.Join(tmp, "a", "b", "c"))
+	touch(t, filepath.Join(tmp, "a", "extra.txt"))
+	touch(t, filepath.Join(tmp, "a", "b", "c", "file.txt"))
+
+	entries := scanDir(tmp, 0, nil, nil)
+	// Expand "a" (not compacted)
+	entries = expandDir(entries, 0)
+	// Expand "b/c" (compacted inside a)
+	for i, e := range entries {
+		if e.name == "b/c" {
+			entries = expandDir(entries, i)
+			break
+		}
+	}
+	paths := expandedPaths(entries)
+
+	// Now remove extra.txt — a should compact into a/b/c
+	if err := os.Remove(filepath.Join(tmp, "a", "extra.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rebuild and restore
+	var newEntries []fileEntry
+	newEntries = scanDir(tmp, 0, newEntries, nil)
+	newEntries = restoreExpanded(newEntries, paths)
+
+	// "a/b/c" should be expanded (restored via intermediate path match)
+	if len(newEntries) == 0 {
+		t.Fatal("expected entries after rebuild")
+	}
+	if newEntries[0].name != "a/b/c" {
+		t.Errorf("want name %q, got %q", "a/b/c", newEntries[0].name)
+	}
+	if !newEntries[0].expanded {
+		t.Error("a/b/c should be restored to expanded state")
+	}
+}


### PR DESCRIPTION
## Overview

Implement VS Code style compact folders in the file tree panel.

## Why

When browsing projects with deep single-child directory chains
(e.g. `src/main/java/com/example/`), each level takes a separate
line in the tree, wasting vertical space and requiring multiple
expand operations. VS Code solves this with `explorer.compactFolders`,
which displays such chains as a single entry like `a/b/c`.

## What

- Extract `listDirContents` helper from `scanDir` to enable reuse
  by the new compaction logic
- Add `compactSingleChildDirs` function that follows chains of
  directories where each has exactly one subdirectory and no files
- Add `compactedPaths` field to `fileEntry` to store intermediate
  directory paths for expansion state restoration
- Update `expandedPaths` to include intermediate paths so that
  tree rebuilds correctly restore expansion when chain structure
  changes (formation or breakage)
- Add `shouldRestore` helper for `restoreExpanded` to match against
  both leaf and intermediate paths

Key design decisions:
- `path` points to the deepest directory so `expandDir`/`collapseDir`
  work without modification
- `depth` uses the shallowest directory's depth for correct indentation
- `renderTree` and `toggleTreeEntry` require no changes

## Related

N/A

## Type of Change

- [x] Feature

## How to Test

```bash
# Run compact folders tests
go test ./internal/tui/ -run "Compact|CompactedEntry|ChainBreaks|ChainForms" -v

# Run all tests
go test ./...
```

Manual verification:
- Open a project with single-child directory chains
- Verify chains display as `a/b/c` in one line
- Expand/collapse works correctly
- Adding/removing files triggers correct tree rebuild with
  expansion state preserved

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed