### PR TITLE
fix: allow pane switch on delete-only diff tabs

### DIFF
--- a/internal/tui/panel_test.go
+++ b/internal/tui/panel_test.go
@@ -145,6 +145,35 @@ func TestSwitchPane_DisabledWhenHidden(t *testing.T) {
 	}
 }
 
+func TestSwitchPane_DeleteOnlyDiff(t *testing.T) {
+	t.Parallel()
+	m := newTestModelWithDiff(t,
+		[]string{"deleted1", "deleted2"}, []string{})
+
+	// Preconditions: delete-only diff has no lines but has diffViewData.
+	tab := m.tabs[m.activeTab]
+	if len(tab.lines) != 0 {
+		t.Fatalf("precondition: len(lines) = %d, want 0", len(tab.lines))
+	}
+	if tab.diffViewData == nil {
+		t.Fatal("precondition: diffViewData should not be nil")
+	}
+	if m.focusPane != paneEditor {
+		t.Fatalf("precondition: focusPane = %d, want paneEditor", m.focusPane)
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyTab}
+	m.Update(msg)
+	if m.focusPane != paneTree {
+		t.Errorf("after 1st Tab: focusPane = %d, want paneTree", m.focusPane)
+	}
+
+	m.Update(msg)
+	if m.focusPane != paneEditor {
+		t.Errorf("after 2nd Tab: focusPane = %d, want paneEditor", m.focusPane)
+	}
+}
+
 func TestRenderLeftPane_LineCount(t *testing.T) {
 	t.Parallel()
 	m := newTestModel(t)

--- a/internal/tui/update_key.go
+++ b/internal/tui/update_key.go
@@ -650,7 +650,7 @@ func (m *Model) handleKeyNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case key.Matches(msg, m.keys.SwitchPane):
-		if hasTab && len(t.lines) > 0 && m.sidebarVisible {
+		if hasTab && (len(t.lines) > 0 || t.diffViewData != nil) && m.sidebarVisible {
 			if m.focusPane == paneEditor {
 				m.notifyClearSelection()
 			}


### PR DESCRIPTION
## Overview

Fix Tab key pane switching being blocked on delete-only diff tabs.

## Why

When viewing a delete-only git diff (file deletion), pressing Tab to switch between the tree and editor panes had no effect. The user was trapped in the editor pane with no way to navigate back to the file tree.

The root cause was the `SwitchPane` condition at `update_key.go:653`:

```go
if hasTab && len(t.lines) > 0 && m.sidebarVisible {
```

For delete-only diffs, `t.lines` is an empty slice (`[]string{}`), so `len(t.lines) > 0` evaluated to `false` and the entire switch was skipped.

## What

- Add `t.diffViewData != nil` as an OR condition so pane switching works when diff data is present, even if `t.lines` is empty
- Add `TestSwitchPane_DeleteOnlyDiff` test following Bug Fix TDD (red-green workflow)

## Related

None

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test ./internal/tui/ -run TestSwitchPane_DeleteOnlyDiff -v
```

Manual verification:
1. Delete a file in a git-tracked project
2. Open gracilius and navigate to Git Changes panel
3. Open the deleted file's diff tab
4. Press Tab — pane should switch between tree and editor

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed